### PR TITLE
Windows support

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -30,11 +30,14 @@ RUN rustup target add x86_64-pc-windows-gnu
 RUN git clone https://github.com/tpoechtrager/osxcross
 RUN cd osxcross && \
 	wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz && \
-    mv MacOSX10.10.sdk.tar.xz tarballs/ && \
-    UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
-RUN chmod +rx /opt/osxcross
-RUN chmod +rx /opt/osxcross/target
-RUN chmod -R +rx /opt/osxcross/target/bin
+    mv MacOSX10.10.sdk.tar.xz tarballs/
+
+# TODO: enable when github is not so flaky
+# RUN cd osxcross && UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
+
+# RUN chmod +rx /opt/osxcross
+# RUN chmod +rx /opt/osxcross/target
+# RUN chmod -R +rx /opt/osxcross/target/bin
 
 # PRE-FETCH MANY DEPS
 WORKDIR /scratch
@@ -56,4 +59,6 @@ RUN mkdir /.cargo
 RUN chmod +rx /.cargo
 COPY build/cargo-config /.cargo/config
 
-CMD ["/opt/build_cross.sh"]
+# TODO: re-enable when github is not so flaky
+# CMD ["/opt/build_cross.sh"]
+CMD ["/opt/build_windows.sh"]

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -7,19 +7,24 @@ RUN apt-get update
 RUN apt install -y clang gcc g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev
 RUN apt install -y build-essential cmake
 
+## add support for windows cross-compile
+RUN apt install -y mingw-w64
+
 # add some llvm configs for later - how to cross-compile this in wasmer-llvm-backend???
 RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt install -y libllvm8 llvm-8 llvm-8-dev llvm-8-runtime
 ENV LLVM_SYS_80_PREFIX=/usr/lib/llvm-8
 
-## ADD MACOS SUPPORT
-
 WORKDIR /opt
 
 # Pin to proper nightly and add macOS Rust target
 RUN rustup default nightly-2020-06-08
+
+# Add macOS and Windows Rust target
 RUN rustup target add x86_64-apple-darwin
+RUN rustup target add x86_64-pc-windows-msvc
+RUN rustup target add x86_64-pc-windows-gnu
 
 # Build osxcross
 RUN git clone https://github.com/tpoechtrager/osxcross
@@ -31,8 +36,6 @@ RUN chmod +rx /opt/osxcross
 RUN chmod +rx /opt/osxcross/target
 RUN chmod -R +rx /opt/osxcross/target/bin
 
-## TODO: add support for windows cross-compile
-
 # PRE-FETCH MANY DEPS
 WORKDIR /scratch
 COPY Cargo.toml /scratch/
@@ -43,7 +46,6 @@ RUN cargo fetch
 RUN chmod -R 777 /usr/local/cargo
 
 ## COPY BUILD SCRIPTS
-
 WORKDIR /code
 RUN rm -rf /scratch
 
@@ -54,4 +56,4 @@ RUN mkdir /.cargo
 RUN chmod +rx /.cargo
 COPY build/cargo-config /.cargo/config
 
-CMD ["/opt/build_osx.sh"]
+CMD ["/opt/build_cross.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build build-rust build-go test docker-image docker-image-centos7 docker-image-cross
 
-DOCKER_TAG := 0.8.2
+DOCKER_TAG := 0.9.0-dev
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)
 

--- a/build/build_cross.sh
+++ b/build/build_cross.sh
@@ -4,5 +4,5 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-"$DIR/build_linux.sh"
+"$DIR/build_windows.sh"
 "$DIR/build_osx.sh"

--- a/build/build_windows.sh
+++ b/build/build_windows.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# ref: https://www.reddit.com/r/rust/comments/5k8uab/crosscompiling_from_ubuntu_to_windows_with_rustup/
+
+cargo build --release --target=x86_64-pc-windows-gnu --verbose
+cp target/x86_64-pc-windows-gnu/release/deps/libgo_cosmwasm.dll api

--- a/build/cargo-config
+++ b/build/cargo-config
@@ -1,3 +1,7 @@
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin14-clang"
 ar = "x86_64-apple-darwin14-ar"
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"
+ar = "x86_64-w64-mingw32-gcc-ar"


### PR DESCRIPTION
Closes #28 

Another try. I heard this is now supported with wasmer, but after building this (`make docker-image-cross && make release`), I get the following:

```
error: This crate doesn't yet support compiling on operating systems and architectures other than these:
       - FreeBSD and x86_64
       - FreeBSD and AArch64
       - macOS and x86_64
       - Linux and x86_64
       - Linux and AArch64
       - Android and x86_64
       - Android and AArch64
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/wasmer-singlepass-backend-0.17.0/src/lib.rs:23:1
```

Maybe it is "just" singlepass that doesn't support windows? Time for a ping