### PR TITLE
docs: Update required rustc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ with a PR (on your fork). We will set up a proper CI system for building these b
 but we are not there yet.
 
 To build the rust side, try `make build-rust` and wait for it to compile. This depends on
-`cargo` being installed with `rustc` version 1.39+. Generally, you can just use `rustup` to
+`cargo` being installed with `rustc` version 1.47+. Generally, you can just use `rustup` to
 install all this with no problems.
 
 ## Toolchain


### PR DESCRIPTION
when I tried build 0.13.x using rustc 1.46.0, it's failed with below error.

> error[E0277]: arrays only have std trait implementations for lengths 0..=32
>    --> packages/std/src/binary.rs:235:25
>     |
> 228 |   pub unsafe trait ByteArray: Sized + AsMut<[u8]> {}
>     |                                       ----------- required by this bound in `binary::ByteArray`
> ...
> 235 |               unsafe impl ByteArray for [u8; $N] {}
>     |                           ^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[u8; 64]`
> ...
> 240 | / implement_fixes_size_arrays! {
> 241 | |      0  1  2  3  4  5  6  7  8  9
> 242 | |     10 11 12 13 14 15 16 17 18 19
> 243 | |     20 21 22 23 24 25 26 27 28 29
> ...   |
> 247 | |     60 61 62 63 64
> 248 | | }
>     | |_- in this macro invocation
>     |
>     = note: required because of the requirements on the impl of `std::convert::AsMut<[u8]>` for `[u8; 64]`
>     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
> error: aborting due to 32 previous errors

It's solved in rustc 1.47.0. see below
https://turreta.com/2020/11/14/rust-array-size-limit-to-32-no-more-in-1-47-0-release/