### PR TITLE
Sort cache methods

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -133,8 +133,6 @@ AnalysisReport analyze_code(cache_t *cache, Buffer contract_checksum, Buffer *er
 
 void free_rust(Buffer buf);
 
-Buffer get_code(cache_t *cache, Buffer contract_checksum, Buffer *err);
-
 Buffer handle(cache_t *cache,
               Buffer contract_checksum,
               Buffer env,
@@ -238,6 +236,8 @@ Buffer instantiate(cache_t *cache,
                    bool print_debug,
                    uint64_t *gas_used,
                    Buffer *err);
+
+Buffer load_wasm(cache_t *cache, Buffer contract_checksum, Buffer *err);
 
 Buffer migrate(cache_t *cache,
                Buffer contract_checksum,

--- a/api/bindings.h
+++ b/api/bindings.h
@@ -131,8 +131,6 @@ Buffer allocate_rust(const uint8_t *ptr, uintptr_t length);
 
 AnalysisReport analyze_code(cache_t *cache, Buffer contract_checksum, Buffer *err);
 
-Buffer create(cache_t *cache, Buffer wasm, Buffer *err);
-
 void free_rust(Buffer buf);
 
 Buffer get_code(cache_t *cache, Buffer contract_checksum, Buffer *err);
@@ -274,3 +272,5 @@ Buffer query(cache_t *cache,
  * and cannot be called on any other pointer.
  */
 void release_cache(cache_t *cache);
+
+Buffer save_wasm(cache_t *cache, Buffer wasm, Buffer *err);

--- a/api/lib.go
+++ b/api/lib.go
@@ -53,7 +53,7 @@ func Create(cache Cache, wasm []byte) ([]byte, error) {
 	code := sendSlice(wasm)
 	defer freeAfterSend(code)
 	errmsg := C.Buffer{}
-	checksum, err := C.create(cache.ptr, code, &errmsg)
+	checksum, err := C.save_wasm(cache.ptr, code, &errmsg)
 	if err != nil {
 		return nil, errorWithMessage(err, errmsg)
 	}

--- a/api/lib.go
+++ b/api/lib.go
@@ -64,11 +64,11 @@ func GetCode(cache Cache, checksum []byte) ([]byte, error) {
 	cs := sendSlice(checksum)
 	defer freeAfterSend(cs)
 	errmsg := C.Buffer{}
-	code, err := C.get_code(cache.ptr, cs, &errmsg)
+	wasm, err := C.load_wasm(cache.ptr, cs, &errmsg)
 	if err != nil {
 		return nil, errorWithMessage(err, errmsg)
 	}
-	return receiveVector(code), nil
+	return receiveVector(wasm), nil
 }
 
 func AnalyzeCode(cache Cache, checksum []byte) (*types.AnalysisReport, error) {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -144,6 +144,24 @@ mod tests {
     }
 
     #[test]
+    fn init_cache_writes_error() {
+        let dir: String = String::from("borken\0dir"); // null bytes are valid UTF8 but not allowed in FS paths
+        let mut err = Buffer::default();
+        let features: &[u8] = b"staking";
+        let cache_ptr = init_cache(
+            dir.as_bytes().into(),
+            features.into(),
+            512,
+            32,
+            Some(&mut err),
+        );
+        assert!(cache_ptr.is_null());
+        assert_ne!(err.len, 0);
+        let msg = String::from_utf8(unsafe { err.consume() }).unwrap();
+        assert_eq!(msg, "Error calling the VM: Cache error: Error creating Wasm dir for cache: data provided contains a nul byte");
+    }
+
+    #[test]
     fn save_wasm_works() {
         let dir: String = TempDir::new().unwrap().path().to_str().unwrap().to_owned();
         let mut err = Buffer::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,32 +55,6 @@ impl From<cosmwasm_vm::AnalysisReport> for AnalysisReport {
 }
 
 #[no_mangle]
-pub extern "C" fn get_code(
-    cache: *mut cache_t,
-    contract_checksum: Buffer,
-    err: Option<&mut Buffer>,
-) -> Buffer {
-    let r = match to_cache(cache) {
-        Some(c) => catch_unwind(AssertUnwindSafe(move || do_get_code(c, contract_checksum)))
-            .unwrap_or_else(|_| Err(Error::panic())),
-        None => Err(Error::empty_arg(CACHE_ARG)),
-    };
-    let data = handle_c_error(r, err);
-    Buffer::from_vec(data)
-}
-
-fn do_get_code(
-    cache: &mut Cache<GoApi, GoStorage, GoQuerier>,
-    contract_checksum: Buffer,
-) -> Result<Vec<u8>, Error> {
-    let contract_checksum: Checksum = unsafe { contract_checksum.read() }
-        .ok_or_else(|| Error::empty_arg(CACHE_ARG))?
-        .try_into()?;
-    let wasm = cache.load_wasm(&contract_checksum)?;
-    Ok(wasm)
-}
-
-#[no_mangle]
 pub extern "C" fn analyze_code(
     cache: *mut cache_t,
     contract_checksum: Buffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use cosmwasm_vm::{
 
 use crate::args::{ARG1, ARG2, CACHE_ARG, CHECKSUM_ARG, ENV_ARG, GAS_USED_ARG, INFO_ARG, MSG_ARG};
 use crate::cache::{cache_t, to_cache};
-use crate::error::{clear_error, handle_c_error, set_error, Error};
+use crate::error::{handle_c_error, Error};
 
 fn into_backend(db: DB, api: GoApi, querier: GoQuerier) -> Backend<GoApi, GoStorage, GoQuerier> {
     Backend {
@@ -38,56 +38,6 @@ fn into_backend(db: DB, api: GoApi, querier: GoQuerier) -> Backend<GoApi, GoStor
         storage: GoStorage::new(db),
         querier,
     }
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-pub struct AnalysisReport {
-    pub has_ibc_entry_points: bool,
-}
-
-impl From<cosmwasm_vm::AnalysisReport> for AnalysisReport {
-    fn from(report: cosmwasm_vm::AnalysisReport) -> Self {
-        AnalysisReport {
-            has_ibc_entry_points: report.has_ibc_entry_points,
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn analyze_code(
-    cache: *mut cache_t,
-    contract_checksum: Buffer,
-    err: Option<&mut Buffer>,
-) -> AnalysisReport {
-    let r = match to_cache(cache) {
-        Some(c) => catch_unwind(AssertUnwindSafe(move || {
-            do_analyze_code(c, contract_checksum)
-        }))
-        .unwrap_or_else(|_| Err(Error::panic())),
-        None => Err(Error::empty_arg(CACHE_ARG)),
-    };
-    match r {
-        Ok(value) => {
-            clear_error();
-            value
-        }
-        Err(error) => {
-            set_error(error, err);
-            AnalysisReport::default()
-        }
-    }
-}
-
-fn do_analyze_code(
-    cache: &mut Cache<GoApi, GoStorage, GoQuerier>,
-    contract_checksum: Buffer,
-) -> Result<AnalysisReport, Error> {
-    let contract_checksum: Checksum = unsafe { contract_checksum.read() }
-        .ok_or_else(|| Error::empty_arg(CACHE_ARG))?
-        .try_into()?;
-    let report = cache.analyze(&contract_checksum)?;
-    Ok(report.into())
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,7 @@ use cosmwasm_vm::{
     Checksum, Instance, InstanceOptions, VmResult,
 };
 
-use crate::args::{
-    ARG1, ARG2, CACHE_ARG, CHECKSUM_ARG, ENV_ARG, GAS_USED_ARG, INFO_ARG, MSG_ARG, WASM_ARG,
-};
+use crate::args::{ARG1, ARG2, CACHE_ARG, CHECKSUM_ARG, ENV_ARG, GAS_USED_ARG, INFO_ARG, MSG_ARG};
 use crate::cache::{cache_t, to_cache};
 use crate::error::{clear_error, handle_c_error, set_error, Error};
 
@@ -54,26 +52,6 @@ impl From<cosmwasm_vm::AnalysisReport> for AnalysisReport {
             has_ibc_entry_points: report.has_ibc_entry_points,
         }
     }
-}
-
-#[no_mangle]
-pub extern "C" fn create(cache: *mut cache_t, wasm: Buffer, err: Option<&mut Buffer>) -> Buffer {
-    let r = match to_cache(cache) {
-        Some(c) => catch_unwind(AssertUnwindSafe(move || do_create(c, wasm)))
-            .unwrap_or_else(|_| Err(Error::panic())),
-        None => Err(Error::empty_arg(CACHE_ARG)),
-    };
-    let data = handle_c_error(r, err);
-    Buffer::from_vec(data)
-}
-
-fn do_create(
-    cache: &mut Cache<GoApi, GoStorage, GoQuerier>,
-    wasm: Buffer,
-) -> Result<Checksum, Error> {
-    let wasm = unsafe { wasm.read() }.ok_or_else(|| Error::empty_arg(WASM_ARG))?;
-    let checksum = cache.save_wasm(wasm)?;
-    Ok(checksum)
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,20 +56,6 @@ impl From<cosmwasm_vm::AnalysisReport> for AnalysisReport {
     }
 }
 
-/// frees a cache reference
-///
-/// # Safety
-///
-/// This must be called exactly once for any `*cache_t` returned by `init_cache`
-/// and cannot be called on any other pointer.
-#[no_mangle]
-pub extern "C" fn release_cache(cache: *mut cache_t) {
-    if !cache.is_null() {
-        // this will free cache when it goes out of scope
-        let _ = unsafe { Box::from_raw(cache as *mut Cache<GoApi, GoStorage, GoQuerier>) };
-    }
-}
-
 #[no_mangle]
 pub extern "C" fn create(cache: *mut cache_t, wasm: Buffer, err: Option<&mut Buffer>) -> Buffer {
     let r = match to_cache(cache) {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -66,12 +66,7 @@ impl Buffer {
 
     // this releases our memory to the caller
     pub fn from_vec(v: Vec<u8>) -> Self {
-        let mut v = mem::ManuallyDrop::new(v);
-        Buffer {
-            ptr: v.as_mut_ptr(),
-            len: v.len(),
-            cap: v.capacity(),
-        }
+        v.into()
     }
 }
 
@@ -82,6 +77,23 @@ impl Default for Buffer {
             len: 0,
             cap: 0,
         }
+    }
+}
+
+impl From<Vec<u8>> for Buffer {
+    fn from(original: Vec<u8>) -> Self {
+        let mut v = mem::ManuallyDrop::new(original);
+        Buffer {
+            ptr: v.as_mut_ptr(),
+            len: v.len(),
+            cap: v.capacity(),
+        }
+    }
+}
+
+impl From<&[u8]> for Buffer {
+    fn from(original: &[u8]) -> Self {
+        original.to_owned().into()
     }
 }
 


### PR DESCRIPTION
- Move all cache methods from `lib.rs` to `cache.rs`
- Write unit tests for them
- Rename to `save_wasm`/`load_wasm` to match the Rust API and better explain what is happening

This prepares https://github.com/CosmWasm/wasmvm/issues/163. Next up

- Connect pin/unpin
- Move all calls into the contract from `lib.rs` to `calls.rs`