### PR TITLE
Create and use OptionalString

### DIFF
--- a/api/mocks.go
+++ b/api/mocks.go
@@ -71,7 +71,7 @@ func MockIBCChannel(channelID string, ordering types.IBCOrder, ibcVersion string
 		},
 		Order:               ordering,
 		Version:             ibcVersion,
-		CounterpartyVersion: ibcVersion,
+		CounterpartyVersion: types.NewOptionalStringSet(ibcVersion),
 		ConnectionID:        "connection-3",
 	}
 }

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -114,7 +114,7 @@ func TestIBCHandshake(t *testing.T) {
 	require.Error(t, err)
 	// passes on good version
 	channel = api.MockIBCChannel(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	channel.CounterpartyVersion = ""
+	channel.CounterpartyVersion = types.NewOptionalStringUnset()
 	_, err = vm.IBCChannelOpen(checksum, env, channel, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 
@@ -168,7 +168,7 @@ func TestIBCPacketDispatch(t *testing.T) {
 	gasMeter2 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
 	store.SetGasMeter(gasMeter2)
 	channel := api.MockIBCChannel(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	channel.CounterpartyVersion = ""
+	channel.CounterpartyVersion = types.NewOptionalStringUnset()
 	_, err = vm.IBCChannelOpen(checksum, env, channel, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 

--- a/types/ibc.go
+++ b/types/ibc.go
@@ -6,13 +6,12 @@ type IBCEndpoint struct {
 }
 
 type IBCChannel struct {
-	Endpoint             IBCEndpoint `json:"endpoint"`
-	CounterpartyEndpoint IBCEndpoint `json:"counterparty_endpoint"`
-	Order                IBCOrder    `json:"order"`
-	Version              string      `json:"version"`
-	// optional
-	CounterpartyVersion string `json:"counterparty_version,omitempty"`
-	ConnectionID        string `json:"connection_id"`
+	Endpoint             IBCEndpoint    `json:"endpoint"`
+	CounterpartyEndpoint IBCEndpoint    `json:"counterparty_endpoint"`
+	Order                IBCOrder       `json:"order"`
+	Version              string         `json:"version"`
+	CounterpartyVersion  OptionalString `json:"counterparty_version"`
+	ConnectionID         string         `json:"connection_id"`
 }
 
 // TODO: test what the sdk Order.String() represents and how to parse back

--- a/types/msg.go
+++ b/types/msg.go
@@ -209,6 +209,8 @@ type InstantiateMsg struct {
 	Send Coins `json:"send"`
 	// Label is optional metadata to be stored with a contract instance.
 	Label string `json:"label"`
+	// Admin (optional) may be set here to allow future migrations from this address
+	Admin OptionalString `json:"admin"`
 }
 
 // MigrateMsg will migrate an existing contract from it's current wasm code (logic)

--- a/types/optional_string.go
+++ b/types/optional_string.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // OptionalString is a type that is able to represent JSON's null or string.
@@ -56,14 +55,10 @@ func (out *OptionalString) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	if data[0] == '"' {
-		var value string
-		if err := json.Unmarshal(data, &value); err != nil {
-			return err
-		}
-		*out = NewOptionalStringSet(value)
-		return nil
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
 	}
-
-	return errors.New("Unexpted JSON type found. Must be null or string.")
+	*out = NewOptionalStringSet(value)
+	return nil
 }

--- a/types/optional_string.go
+++ b/types/optional_string.go
@@ -1,0 +1,69 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// OptionalString is a type that is able to represent JSON's null or string.
+// It allows us to differentiate between a null field and an empty string.
+// The corresponding Rust type is Option<String>.
+// If you want to treat null the same way as the empty string, use .String()
+// which maps the two to an empty string.
+type OptionalString struct {
+	Set bool
+	/// Value is the string value when Set is true. When Set is unset, this field must be ignored.
+	Value string
+}
+
+func NewOptionalStringUnset() OptionalString {
+	return OptionalString{
+		Set:   false,
+		Value: "don't use me",
+	}
+}
+
+func NewOptionalStringSet(value string) OptionalString {
+	return OptionalString{
+		Set:   true,
+		Value: value,
+	}
+}
+
+// String converts the OptionalString to a string by mapping unset
+// to an empty string. Use this when you not need the differentiation anymore.
+func (os OptionalString) String() string {
+	if os.Set == false {
+		return ""
+	} else {
+		return os.Value
+	}
+}
+
+// MarshalJSON encodes a set OptionalString to a JSON string and an unset OptionalString to a JSON null
+func (in OptionalString) MarshalJSON() ([]byte, error) {
+	if in.Set == false {
+		return []byte("null"), nil
+	} else {
+		return json.Marshal(in.Value)
+	}
+}
+
+// UnmarshalJSON decodes a JSON string to a set OptionalString and null to an unset OptionalString
+func (out *OptionalString) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*out = NewOptionalStringUnset()
+		return nil
+	}
+
+	if data[0] == '"' {
+		var value string
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		*out = NewOptionalStringSet(value)
+		return nil
+	}
+
+	return errors.New("Unexpted JSON type found. Must be null or string.")
+}

--- a/types/optional_string_test.go
+++ b/types/optional_string_test.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestOptionalStringDefaultValue(t *testing.T) {
+	var os OptionalString
+	assert.Equal(t, false, os.Set)
+}
+
+func TestNewOptionalString(t *testing.T) {
+	os := NewOptionalStringSet("abc")
+	assert.Equal(t, "abc", os.String())
+
+	os = NewOptionalStringSet("")
+	assert.Equal(t, "", os.String())
+
+	os = NewOptionalStringUnset()
+	assert.Equal(t, "", os.String())
+}
+
+func TestOptionalStringToString(t *testing.T) {
+	os := NewOptionalStringSet("abc")
+	assert.Equal(t, OptionalString{Set: true, Value: "abc"}, os)
+
+	os = NewOptionalStringSet("")
+	assert.Equal(t, OptionalString{Set: true, Value: ""}, os)
+
+	os = NewOptionalStringUnset()
+	assert.Equal(t, false, os.Set)
+}
+
+func TestOptionalStringMarshalJSON(t *testing.T) {
+	alice := NewOptionalStringSet("alice")
+	bytes, err := json.Marshal(alice)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("\"alice\""), bytes)
+
+	empty := NewOptionalStringSet("")
+	bytes, err = json.Marshal(empty)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("\"\""), bytes)
+
+	unset := NewOptionalStringUnset()
+	bytes, err = json.Marshal(unset)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("null"), bytes)
+}
+
+func TestOptionalStringUnmarshalJSON(t *testing.T) {
+	var os OptionalString
+
+	err := json.Unmarshal([]byte("null"), &os)
+	require.NoError(t, err)
+	assert.Equal(t, false, os.Set)
+
+	err = json.Unmarshal([]byte("\"\""), &os)
+	require.NoError(t, err)
+	assert.Equal(t, OptionalString{Set: true, Value: ""}, os)
+
+	err = json.Unmarshal([]byte("\"abc\""), &os)
+	require.NoError(t, err)
+	assert.Equal(t, OptionalString{Set: true, Value: "abc"}, os)
+
+	err = json.Unmarshal([]byte("123"), &os)
+	// TODO: Use ErrorContains once released (https://github.com/stretchr/testify/commit/6990a05d54)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unexpted JSON type")
+}

--- a/types/optional_string_test.go
+++ b/types/optional_string_test.go
@@ -69,5 +69,20 @@ func TestOptionalStringUnmarshalJSON(t *testing.T) {
 	err = json.Unmarshal([]byte("123"), &os)
 	// TODO: Use ErrorContains once released (https://github.com/stretchr/testify/commit/6990a05d54)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Unexpted JSON type")
+	require.Contains(t, err.Error(), "cannot unmarshal number into Go value of type string")
+
+	err = json.Unmarshal([]byte("[]"), &os)
+	// TODO: Use ErrorContains once released (https://github.com/stretchr/testify/commit/6990a05d54)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot unmarshal array into Go value of type string")
+
+	err = json.Unmarshal([]byte("false"), &os)
+	// TODO: Use ErrorContains once released (https://github.com/stretchr/testify/commit/6990a05d54)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot unmarshal bool into Go value of type string")
+
+	err = json.Unmarshal([]byte(""), &os)
+	// TODO: Use ErrorContains once released (https://github.com/stretchr/testify/commit/6990a05d54)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected end of JSON input")
 }

--- a/types/queries.go
+++ b/types/queries.go
@@ -132,8 +132,7 @@ type PortIDResponse struct {
 // Returns a `ListChannelsResponse`.
 // This is the counterpart of [IbcQuery::ListChannels](https://github.com/CosmWasm/cosmwasm/blob/v0.14.0-beta1/packages/std/src/ibc.rs#L70-L73).
 type ListChannelsQuery struct {
-	// optional argument
-	PortID string `json:"port_id,omitempty"`
+	PortID OptionalString `json:"port_id"`
 }
 
 type ListChannelsResponse struct {
@@ -193,9 +192,8 @@ func (e *IBCEndpoints) UnmarshalJSON(data []byte) error {
 }
 
 type ChannelQuery struct {
-	// optional argument
-	PortID    string `json:"port_id,omitempty"`
-	ChannelID string `json:"channel_id"`
+	PortID    OptionalString `json:"port_id"`
+	ChannelID string         `json:"channel_id"`
 }
 
 type ChannelResponse struct {


### PR DESCRIPTION
This is an alternative approach to the problem discussed in https://github.com/CosmWasm/wasmvm/pull/213. It allows us to send optional strings between Rust and Go via JSON without losing information. The advantage here is that we can use this in any direction for any field. Once the application (x/wasm) decides to not care about the differentiation between null and an empty string, it can simply call `.String()`. For optional addresses it would even be better to consider `""` as an error because it is not valis bech32. But this is up to the caller. It get's all the choice.