### PR TITLE
Add Windows support to cross builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@2.2.0
+
 jobs:
   # All checks on the codebase that can run in parallel to build_shared_library
   libwasmvm_sanity:
@@ -179,6 +182,22 @@ jobs:
           command: make test-safety
       - run: make build-go
 
+  # Note: this is pretty limited right now because it only tests the checked-in
+  # wasmvm.dll without rebuilding it.
+  test-windows:
+    executor:
+      name: win/default
+      shell: powershell.exe
+    steps:
+      - checkout
+      - run: systeminfo
+      - run:
+          name: Install mingw
+          command: choco install mingw
+      - run:
+          name: Run go tests using wasmvm.dll
+          command: go test -v ./api ./types .
+
   test_alpine_build:
     machine:
       image: ubuntu-2004:202101-01
@@ -282,6 +301,7 @@ workflows:
       - tidy-go
       - format-scripts
       - lint-scripts
+      - test-windows
       - build_shared_library:
           filters: # required since other jobs with tag filters require this one
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,28 @@ jobs:
           command: make test-safety
       - run: make build-go
 
+  rust-unit-tests-windows:
+    executor:
+      name: win/default
+      shell: powershell.exe
+    environment:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - checkout
+      - run:
+          name: Install Rustup
+          command: choco install rustup.install
+      - run:
+          name: Install Rust
+          command: rustup default 1.55.0
+      - run:
+          name: Show Rust version information
+          command: rustc --version; cargo --version; rustup --version
+      - run:
+          name: Run unit tests
+          working_directory: libwasmvm
+          command: cargo test
+
   # Note: this is pretty limited right now because it only tests the checked-in
   # wasmvm.dll without rebuilding it.
   test-windows:
@@ -301,6 +323,7 @@ workflows:
       - tidy-go
       - format-scripts
       - lint-scripts
+      - rust-unit-tests-windows
       - test-windows
       - build_shared_library:
           filters: # required since other jobs with tag filters require this one

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,9 @@ jobs:
           name: Build shared library for macOS
           command: make release-build-macos
       - run:
+          name: Build shared library for Windows
+          command: make release-build-windows
+      - run:
           name: Debug build results
           command: ls -l ./api
       - run:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: all build build-rust build-go test
 
 # Builds the Rust library libwasmvm
-BUILDERS_PREFIX := cosmwasm/go-ext-builder:0008
+BUILDERS_PREFIX := cosmwasm/go-ext-builder:0009
 # Contains a full Go dev environment in order to run Go tests on the built library
-ALPINE_TESTER := cosmwasm/go-ext-builder:0008-alpine
+ALPINE_TESTER := cosmwasm/go-ext-builder:0009-alpine
 
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)
@@ -74,8 +74,16 @@ release-build-linux:
 # Creates a release build in a containerized build environment of the shared library for macOS (.dylib)
 release-build-macos:
 	rm -rf libwasmvm/target/release
-	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd)/libwasmvm:/code $(BUILDERS_PREFIX)-cross
+	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd)/libwasmvm:/code $(BUILDERS_PREFIX)-cross build_macos.sh
 	cp libwasmvm/target/x86_64-apple-darwin/release/deps/libwasmvm.dylib api
+	cp libwasmvm/bindings.h api
+	make update-bindings
+
+# Creates a release build in a containerized build environment of the shared library for Windows (.dll)
+release-build-windows:
+	rm -rf libwasmvm/target/release
+	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd)/libwasmvm:/code $(BUILDERS_PREFIX)-cross build_windows.sh
+	cp libwasmvm/target/x86_64-pc-windows-gnu/release/wasmvm.dll api
 	cp libwasmvm/bindings.h api
 	make update-bindings
 

--- a/api/link_muslc.go
+++ b/api/link_muslc.go
@@ -1,5 +1,4 @@
 //go:build linux && muslc
-// +build linux,muslc
 
 package api
 

--- a/api/link_std.go
+++ b/api/link_std.go
@@ -1,4 +1,4 @@
-//go:build (linux && !muslc) || darwin
+//go:build (linux && !muslc) || darwin || windows
 
 package api
 

--- a/api/link_std.go
+++ b/api/link_std.go
@@ -1,5 +1,4 @@
 //go:build (linux && !muslc) || darwin
-// +build linux,!muslc darwin
 
 package api
 

--- a/builders/Dockerfile.cross
+++ b/builders/Dockerfile.cross
@@ -1,9 +1,11 @@
 FROM rust:1.55.0-buster
 
 # Install build dependencies
-RUN apt-get update
-RUN apt install -y clang gcc g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev
-RUN apt install -y build-essential cmake
+RUN apt-get update && apt install -y \
+  clang gcc g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev \
+  build-essential cmake \
+  # Support for Windows cross-compile
+  mingw-w64
 
 # add some llvm configs for later - how to cross-compile this in wasmer-llvm-backend???
 RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list
@@ -15,15 +17,17 @@ ENV LLVM_SYS_80_PREFIX=/usr/lib/llvm-8
 
 WORKDIR /opt
 
-# Add macOS Rust target
-RUN rustup target add x86_64-apple-darwin
+# Add macOS and Windows Rust targets
+RUN rustup target add x86_64-apple-darwin x86_64-pc-windows-gnu
 
 # Build osxcross
-RUN git clone https://github.com/tpoechtrager/osxcross
-RUN cd osxcross && \
-	wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz && \
-    mv MacOSX10.10.sdk.tar.xz tarballs/ && \
-    UNATTENDED=yes OSX_VERSION_MIN=10.10 ./build.sh
+RUN git clone https://github.com/tpoechtrager/osxcross \
+  && cd osxcross \
+  && wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz \
+  && mv MacOSX10.10.sdk.tar.xz tarballs/ \
+  && UNATTENDED=yes OSX_VERSION_MIN=10.10 ./build.sh \
+  # Cleanups before Docker layer is finalized
+  && rm -r tarballs/
 RUN chmod +rx /opt/osxcross
 RUN chmod +rx /opt/osxcross/target
 RUN chmod -R +rx /opt/osxcross/target/bin
@@ -35,11 +39,11 @@ RUN chmod -R 777 /usr/local/cargo
 
 WORKDIR /code
 
-COPY guest/*.sh /opt/
-RUN chmod +x /opt/*.sh
+COPY guest/*.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/*.sh
 
 RUN mkdir /.cargo
 RUN chmod +rx /.cargo
 COPY guest/cargo-config /.cargo/config
 
-CMD ["/opt/build_macos.sh"]
+CMD ["bash", "-c", "echo 'Argument missing. Pass one of build_macos.sh or build_windows.sh to docker run' && exit 1"]

--- a/builders/Makefile
+++ b/builders/Makefile
@@ -1,6 +1,6 @@
 # Versioned by a simple counter that is not bound to a specific CosmWasm version
 # See builders/README.md
-BUILDERS_PREFIX := cosmwasm/go-ext-builder:0008
+BUILDERS_PREFIX := cosmwasm/go-ext-builder:0009
 
 .PHONY: docker-image-centos7
 docker-image-centos7:

--- a/builders/README.md
+++ b/builders/README.md
@@ -14,6 +14,10 @@ can do the cross-compilation.
 
 ## Changelog
 
+**Version 0009:**
+
+- Add Windows support to cosmwasm/go-ext-builder:0009-cross. This image builds for macOS and Windows now.
+
 **Version 0008:**
 
 - Update Rust to 1.55.0 and Go (for testing only) to 1.17.5.

--- a/builders/guest/build_linux.sh
+++ b/builders/guest/build_linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 
 # See https://github.com/CosmWasm/wasmvm/issues/222#issuecomment-880616953 for two approaches to
 # enable stripping through cargo (if that is desired).

--- a/builders/guest/build_macos.sh
+++ b/builders/guest/build_macos.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 
 # ref: https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html
 export PATH="/opt/osxcross/target/bin:$PATH"

--- a/builders/guest/build_windows.sh
+++ b/builders/guest/build_windows.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# ref: https://www.reddit.com/r/rust/comments/5k8uab/crosscompiling_from_ubuntu_to_windows_with_rustup/
+
+cargo build --release --target x86_64-pc-windows-gnu

--- a/builders/guest/build_windows.sh
+++ b/builders/guest/build_windows.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 
 # ref: https://www.reddit.com/r/rust/comments/5k8uab/crosscompiling_from_ubuntu_to_windows_with_rustup/
 

--- a/builders/guest/cargo-config
+++ b/builders/guest/cargo-config
@@ -1,3 +1,7 @@
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin14-clang"
 ar = "x86_64-apple-darwin14-ar"
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"
+ar = "x86_64-w64-mingw32-gcc-ar"


### PR DESCRIPTION
This largely builds on #117 which can now be used with Wasmer 2.1.
With this we can build an api/wasmvm.dll. 

Closes #117
Closes #28