### PR TITLE
Added support to centos7 builder for ARM

### DIFF
--- a/builders/Dockerfile.centos7
+++ b/builders/Dockerfile.centos7
@@ -1,4 +1,5 @@
 FROM centos:centos7
+ARG arch=x86_64
 
 RUN yum -y update \
   && yum -y install clang gcc gcc-c++ make wget
@@ -8,7 +9,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+RUN wget "https://static.rust-lang.org/rustup/dist/${arch}-unknown-linux-gnu/rustup-init" \
   && chmod +x rustup-init \
   && ./rustup-init -y --no-modify-path --default-toolchain 1.55.0 \
   && rm rustup-init \

--- a/builders/Makefile
+++ b/builders/Makefile
@@ -4,7 +4,11 @@ BUILDERS_PREFIX := cosmwasm/go-ext-builder:0009
 
 .PHONY: docker-image-centos7
 docker-image-centos7:
+ifdef ARM64
+	docker build --platform linux/arm64 . -t $(BUILDERS_PREFIX)-centos7 -f ./Dockerfile.centos7 --build-arg arch=aarch64
+else
 	docker build . -t $(BUILDERS_PREFIX)-centos7 -f ./Dockerfile.centos7
+endif
 
 .PHONY: docker-image-cross
 docker-image-cross:

--- a/builders/README.md
+++ b/builders/README.md
@@ -14,6 +14,9 @@ can do the cross-compilation.
 
 ## Changelog
 
+**Version 0009b**
+- Added ARM64 flag to enable/disable building of arrch64 for centos. ARM64=1
+
 **Version 0009:**
 
 - Let macOS build dylib files with both aarch64 and x86_64 code.


### PR DESCRIPTION
An additional fix for Issue #53.

- Updates the centos7 Dockerfile to optionally build for AARCH64
- Includes a prebuilt shared library libwasmvm.aarch64.so