### PR TITLE
Expose libwasmvm version number at runtime

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -476,3 +476,40 @@ struct UnmanagedVector ibc_packet_timeout(struct cache_t *cache,
 struct UnmanagedVector new_unmanaged_vector(bool nil, const uint8_t *ptr, uintptr_t length);
 
 void destroy_unmanaged_vector(struct UnmanagedVector v);
+
+/**
+ * Returns a version number of this library in the form 0xEEEEXXXXYYYYZZZZ
+ * with two-byte hexadecimal values EEEE, XXXX, YYYY, ZZZZ from 0 to 65535 each.
+ *
+ * EEEE represents the error value with 0 meaning no error.
+ * XXXX is the major version, YYYY is the minor version and ZZZZ is the patch version.
+ *
+ * ## Examples
+ *
+ * The version number can be decomposed like this:
+ *
+ * ```
+ * # use wasmvm::version_number;
+ * let version = version_number();
+ * let patch = version >> 0 & 0xFFFF;
+ * let minor = version >> 16 & 0xFFFF;
+ * let major = version >> 32 & 0xFFFF;
+ * let error = version >> 48 & 0xFFFF;
+ * assert_eq!(error, 0);
+ * assert_eq!(major, 1);
+ * assert!(minor < 70);
+ * assert!(patch < 70);
+ * ```
+ *
+ * And compared like this:
+ *
+ * ```
+ * # use wasmvm::{make_version_number, version_number};
+ * let min_version = make_version_number(0, 17, 25);
+ * let version = version_number();
+ * let error = version >> 48 & 0xFFFF;
+ * assert_eq!(error, 0);
+ * assert!(version >= min_version);
+ * ```
+ */
+uint64_t version_number(void);

--- a/api/bindings.h
+++ b/api/bindings.h
@@ -478,38 +478,8 @@ struct UnmanagedVector new_unmanaged_vector(bool nil, const uint8_t *ptr, uintpt
 void destroy_unmanaged_vector(struct UnmanagedVector v);
 
 /**
- * Returns a version number of this library in the form 0xEEEEXXXXYYYYZZZZ
- * with two-byte hexadecimal values EEEE, XXXX, YYYY, ZZZZ from 0 to 65535 each.
+ * Returns a version number of this library as a C string.
  *
- * EEEE represents the error value with 0 meaning no error.
- * XXXX is the major version, YYYY is the minor version and ZZZZ is the patch version.
- *
- * ## Examples
- *
- * The version number can be decomposed like this:
- *
- * ```
- * # use wasmvm::version_number;
- * let version = version_number();
- * let patch = version >> 0 & 0xFFFF;
- * let minor = version >> 16 & 0xFFFF;
- * let major = version >> 32 & 0xFFFF;
- * let error = version >> 48 & 0xFFFF;
- * assert_eq!(error, 0);
- * assert_eq!(major, 1);
- * assert!(minor < 70);
- * assert!(patch < 70);
- * ```
- *
- * And compared like this:
- *
- * ```
- * # use wasmvm::{make_version_number, version_number};
- * let min_version = make_version_number(0, 17, 25);
- * let version = version_number();
- * let error = version >> 48 & 0xFFFF;
- * assert_eq!(error, 0);
- * assert!(version >= min_version);
- * ```
+ * The string is owned by libwasmvm and must not be mutated or destroyed by the caller.
  */
-uint64_t version_number(void);
+const char *version_str(void);

--- a/api/version.go
+++ b/api/version.go
@@ -1,0 +1,26 @@
+package api
+
+// #include "bindings.h"
+import "C"
+
+import (
+	"fmt"
+)
+
+// LibwasmvmVersion returns the version of the loaded library
+// at runtime. This can be used to verify if the loaded version
+// matches the expected version.
+func LibwasmvmVersion() (string, error) {
+	version, err := C.version_number()
+	if err != nil {
+		return "", err
+	}
+	patch := version >> 0 & 0xFFFF
+	minor := version >> 16 & 0xFFFF
+	major := version >> 32 & 0xFFFF
+	error := version >> 48 & 0xFFFF
+	if error != 0 {
+		return "", fmt.Errorf("Error code from version_number call: %d", error)
+	}
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch), nil
+}

--- a/api/version.go
+++ b/api/version.go
@@ -1,26 +1,20 @@
 package api
 
-// #include "bindings.h"
+/*
+#include "bindings.h"
+*/
 import "C"
 
-import (
-	"fmt"
-)
-
 // LibwasmvmVersion returns the version of the loaded library
-// at runtime. This can be used to verify if the loaded version
+// at runtime. This can be used for debugging to verify the loaded version
 // matches the expected version.
 func LibwasmvmVersion() (string, error) {
-	version, err := C.version_number()
+	version_ptr, err := C.version_str()
 	if err != nil {
 		return "", err
 	}
-	patch := version >> 0 & 0xFFFF
-	minor := version >> 16 & 0xFFFF
-	major := version >> 32 & 0xFFFF
-	error := version >> 48 & 0xFFFF
-	if error != 0 {
-		return "", fmt.Errorf("Error code from version_number call: %d", error)
-	}
-	return fmt.Sprintf("%d.%d.%d", major, minor, patch), nil
+	// For C.GoString documentation see https://pkg.go.dev/cmd/cgo and
+	// https://gist.github.com/helinwang/2c7bd2867ea5110f70e6431a7c80cd9b
+	version_copy := C.GoString(version_ptr)
+	return version_copy, nil
 }

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,5 +10,5 @@ import (
 func TestLibwasmvmVersion(t *testing.T) {
 	version, err := LibwasmvmVersion()
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0", version)
+	require.Regexp(t, regexp.MustCompile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"), version)
 }

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLibwasmvmVersion(t *testing.T) {
+	version, err := LibwasmvmVersion()
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", version)
+}

--- a/libwasmvm/Cargo.lock
+++ b/libwasmvm/Cargo.lock
@@ -1805,7 +1805,7 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmvm"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "cbindgen",
  "cosmwasm-std",

--- a/libwasmvm/Cargo.toml
+++ b/libwasmvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmvm"
-version = "0.0.0"
+version = "1.0.0"
 publish = false
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"

--- a/libwasmvm/bindings.h
+++ b/libwasmvm/bindings.h
@@ -476,3 +476,40 @@ struct UnmanagedVector ibc_packet_timeout(struct cache_t *cache,
 struct UnmanagedVector new_unmanaged_vector(bool nil, const uint8_t *ptr, uintptr_t length);
 
 void destroy_unmanaged_vector(struct UnmanagedVector v);
+
+/**
+ * Returns a version number of this library in the form 0xEEEEXXXXYYYYZZZZ
+ * with two-byte hexadecimal values EEEE, XXXX, YYYY, ZZZZ from 0 to 65535 each.
+ *
+ * EEEE represents the error value with 0 meaning no error.
+ * XXXX is the major version, YYYY is the minor version and ZZZZ is the patch version.
+ *
+ * ## Examples
+ *
+ * The version number can be decomposed like this:
+ *
+ * ```
+ * # use wasmvm::version_number;
+ * let version = version_number();
+ * let patch = version >> 0 & 0xFFFF;
+ * let minor = version >> 16 & 0xFFFF;
+ * let major = version >> 32 & 0xFFFF;
+ * let error = version >> 48 & 0xFFFF;
+ * assert_eq!(error, 0);
+ * assert_eq!(major, 1);
+ * assert!(minor < 70);
+ * assert!(patch < 70);
+ * ```
+ *
+ * And compared like this:
+ *
+ * ```
+ * # use wasmvm::{make_version_number, version_number};
+ * let min_version = make_version_number(0, 17, 25);
+ * let version = version_number();
+ * let error = version >> 48 & 0xFFFF;
+ * assert_eq!(error, 0);
+ * assert!(version >= min_version);
+ * ```
+ */
+uint64_t version_number(void);

--- a/libwasmvm/bindings.h
+++ b/libwasmvm/bindings.h
@@ -478,38 +478,8 @@ struct UnmanagedVector new_unmanaged_vector(bool nil, const uint8_t *ptr, uintpt
 void destroy_unmanaged_vector(struct UnmanagedVector v);
 
 /**
- * Returns a version number of this library in the form 0xEEEEXXXXYYYYZZZZ
- * with two-byte hexadecimal values EEEE, XXXX, YYYY, ZZZZ from 0 to 65535 each.
+ * Returns a version number of this library as a C string.
  *
- * EEEE represents the error value with 0 meaning no error.
- * XXXX is the major version, YYYY is the minor version and ZZZZ is the patch version.
- *
- * ## Examples
- *
- * The version number can be decomposed like this:
- *
- * ```
- * # use wasmvm::version_number;
- * let version = version_number();
- * let patch = version >> 0 & 0xFFFF;
- * let minor = version >> 16 & 0xFFFF;
- * let major = version >> 32 & 0xFFFF;
- * let error = version >> 48 & 0xFFFF;
- * assert_eq!(error, 0);
- * assert_eq!(major, 1);
- * assert!(minor < 70);
- * assert!(patch < 70);
- * ```
- *
- * And compared like this:
- *
- * ```
- * # use wasmvm::{make_version_number, version_number};
- * let min_version = make_version_number(0, 17, 25);
- * let version = version_number();
- * let error = version >> 48 & 0xFFFF;
- * assert_eq!(error, 0);
- * assert!(version >= min_version);
- * ```
+ * The string is owned by libwasmvm and must not be mutated or destroyed by the caller.
  */
-uint64_t version_number(void);
+const char *version_str(void);

--- a/libwasmvm/src/lib.rs
+++ b/libwasmvm/src/lib.rs
@@ -27,4 +27,3 @@ pub use memory::{
 };
 pub use querier::GoQuerier;
 pub use storage::GoStorage;
-pub use version::{make_version_number, version_number};

--- a/libwasmvm/src/lib.rs
+++ b/libwasmvm/src/lib.rs
@@ -13,6 +13,7 @@ mod memory;
 mod querier;
 mod storage;
 mod tests;
+mod version;
 
 // We only interact with this crate via `extern "C"` interfaces, not those public
 // exports. There are no guarantees those exports are stable.
@@ -26,3 +27,4 @@ pub use memory::{
 };
 pub use querier::GoQuerier;
 pub use storage::GoStorage;
+pub use version::{make_version_number, version_number};

--- a/libwasmvm/src/version.rs
+++ b/libwasmvm/src/version.rs
@@ -1,0 +1,93 @@
+/// Returns a version number of this library in the form 0xEEEEXXXXYYYYZZZZ
+/// with two-byte hexadecimal values EEEE, XXXX, YYYY, ZZZZ from 0 to 65535 each.
+///
+/// EEEE represents the error value with 0 meaning no error.
+/// XXXX is the major version, YYYY is the minor version and ZZZZ is the patch version.
+///
+/// ## Examples
+///
+/// The version number can be decomposed like this:
+///
+/// ```
+/// # use wasmvm::version_number;
+/// let version = version_number();
+/// let patch = version >> 0 & 0xFFFF;
+/// let minor = version >> 16 & 0xFFFF;
+/// let major = version >> 32 & 0xFFFF;
+/// let error = version >> 48 & 0xFFFF;
+/// assert_eq!(error, 0);
+/// assert_eq!(major, 1);
+/// assert!(minor < 70);
+/// assert!(patch < 70);
+/// ```
+///
+/// And compared like this:
+///
+/// ```
+/// # use wasmvm::{make_version_number, version_number};
+/// let min_version = make_version_number(0, 17, 25);
+/// let version = version_number();
+/// let error = version >> 48 & 0xFFFF;
+/// assert_eq!(error, 0);
+/// assert!(version >= min_version);
+/// ```
+#[no_mangle]
+pub extern "C" fn version_number() -> u64 {
+    match version_number_impl() {
+        Ok([major, minor, patch]) => make_version_number(major, minor, patch),
+        Err(err) => {
+            let error = err as u16;
+            let [b0, b1] = error.to_be_bytes();
+            u64::from_be_bytes([b0, b1, 0, 0, 0, 0, 0, 0])
+        }
+    }
+}
+
+/// Creates a version number from the three components major.minor.patch.
+///
+/// See [`version_number`] for more details.
+pub fn make_version_number(major: u16, minor: u16, patch: u16) -> u64 {
+    let [b2, b3] = major.to_be_bytes();
+    let [b4, b5] = minor.to_be_bytes();
+    let [b6, b7] = patch.to_be_bytes();
+    u64::from_be_bytes([0, 0, b2, b3, b4, b5, b6, b7])
+}
+
+// Errors will be converted to u16 and passed over the FFI
+// using big endian encoding.
+enum VersionNumberError {
+    CannotParseMajor = 1,
+    CannotParseMinor,
+    CannotParsePatch,
+}
+
+fn version_number_impl() -> Result<[u16; 3], VersionNumberError> {
+    let major: u16 = env!("CARGO_PKG_VERSION_MAJOR")
+        .parse()
+        .map_err(|_| VersionNumberError::CannotParseMajor)?;
+    let minor: u16 = env!("CARGO_PKG_VERSION_MINOR")
+        .parse()
+        .map_err(|_| VersionNumberError::CannotParseMinor)?;
+    let patch: u16 = env!("CARGO_PKG_VERSION_PATCH")
+        .parse()
+        .map_err(|_| VersionNumberError::CannotParsePatch)?;
+    Ok([major, minor, patch])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_number_works() {
+        let version = version_number();
+        let patch = version >> 0 & 0xFFFF;
+        let minor = version >> 16 & 0xFFFF;
+        let major = version >> 32 & 0xFFFF;
+        let error = version >> 48 & 0xFFFF;
+        assert_eq!(error, 0);
+        assert_eq!(major, 1);
+        assert!(minor < 70);
+        assert!(patch < 70);
+    }
+}


### PR DESCRIPTION
Sometimes it's tricky for validators to get the correct .so file used with their binary. This happens when the binary is built on one system and is then deployed to multiple nodes. Go installs the .so to a very custom path in the Go installation system.

Now what we want to do is provide information of the Rust side (libwasmvm) at runtime. This way you can veryify that your wasmvm 1.2.3 dependency loaded the 1.2.3 shared library and not something old that was installed from last time such as 1.2.1.

Ideally we find a way to get this listed in the chain's long version output, e.g. in here

```
$ junod version --long
name: juno
server_name: junod
version: v3.1.0
commit: dd595e9ec533eabed8a7b588c64e2cc638fbf24e
build_tags: netgo,ledger
go: go version go1.17 linux/amd64
build_deps:
- filippo.io/edwards25519@v1.0.0-beta.2
- github.com/99designs/keyring@v1.1.6
- github.com/ChainSafe/go-schnorrkel@v0.0.0-20200405005733-88cbf1b4c40d
[...]
- gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b
- nhooyr.io/websocket@v1.8.6
cosmos_sdk_version: v0.45.1

```

With this PR the release process needs a bit more steps since the libwasmvm project version needs to be updated before the release tag is set.