### PR TITLE
Create frame limit for iterator frames

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -246,7 +246,10 @@ typedef struct U8SliceView {
 } U8SliceView;
 
 typedef struct iterator_t {
-  uint64_t db_counter;
+  /**
+   * An ID assigned to this contract call
+   */
+  uint64_t call_id;
   uint64_t iterator_index;
 } iterator_t;
 

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -131,18 +131,18 @@ var db_vtable = C.Db_vtable{
 
 type DBState struct {
 	Store KVStore
-	// IteratorStackID is used to lookup the proper stack frame for iterators associated with this DB (iterator.go)
-	IteratorStackID uint64
+	// CallID is used to lookup the proper frame for iterators associated with this contract call (iterator.go)
+	CallID uint64
 }
 
 // use this to create C.Db in two steps, so the pointer lives as long as the calling stack
-//   state := buildDBState(kv, counter)
+//   state := buildDBState(kv, callID)
 //   db := buildDB(&state, &gasMeter)
 //   // then pass db into some FFI function
-func buildDBState(kv KVStore, counter uint64) DBState {
+func buildDBState(kv KVStore, callID uint64) DBState {
 	return DBState{
-		Store:           kv,
-		IteratorStackID: counter,
+		Store:  kv,
+		CallID: callID,
 	}
 }
 
@@ -162,10 +162,10 @@ var iterator_vtable = C.Iterator_vtable{
 
 // contract: original pointer/struct referenced must live longer than C.Db struct
 // since this is only used internally, we can verify the code that this is the case
-func buildIterator(dbCounter uint64, it dbm.Iterator) C.iterator_t {
-	idx := storeIterator(dbCounter, it)
+func buildIterator(callID uint64, it dbm.Iterator) C.iterator_t {
+	idx := storeIterator(callID, it)
 	return C.iterator_t{
-		db_counter:     cu64(dbCounter),
+		call_id:        cu64(callID),
 		iterator_index: cu64(idx),
 	}
 }
@@ -278,7 +278,7 @@ func cScan(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, start C.U8
 	gasAfter := gm.GasConsumed()
 	*usedGas = (C.uint64_t)(gasAfter - gasBefore)
 
-	out.state = buildIterator(state.IteratorStackID, iter)
+	out.state = buildIterator(state.CallID, iter)
 	out.vtable = iterator_vtable
 	return C.GoError_None
 }
@@ -292,7 +292,7 @@ func cNext(ref C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *
 	// 	}
 
 	defer recoverPanic(&ret)
-	if ref.db_counter == 0 || gasMeter == nil || usedGas == nil || key == nil || val == nil || errOut == nil {
+	if ref.call_id == 0 || gasMeter == nil || usedGas == nil || key == nil || val == nil || errOut == nil {
 		// we received an invalid pointer
 		return C.GoError_BadArgument
 	}
@@ -301,7 +301,7 @@ func cNext(ref C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *
 	}
 
 	gm := *(*GasMeter)(unsafe.Pointer(gasMeter))
-	iter := retrieveIterator(uint64(ref.db_counter), uint64(ref.iterator_index))
+	iter := retrieveIterator(uint64(ref.call_id), uint64(ref.iterator_index))
 	if !iter.Valid() {
 		// end of iterator, return as no-op, nil key is considered end
 		return C.GoError_None

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -302,6 +302,9 @@ func cNext(ref C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *
 
 	gm := *(*GasMeter)(unsafe.Pointer(gasMeter))
 	iter := retrieveIterator(uint64(ref.call_id), uint64(ref.iterator_index))
+	if iter == nil {
+		panic("Unable to retrieve iterator.")
+	}
 	if !iter.Valid() {
 		// end of iterator, return as no-op, nil key is considered end
 		return C.GoError_None

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -10,8 +10,7 @@ import (
 type frame []dbm.Iterator
 
 // iteratorStack contains one frame for each contract call, indexed by contract call ID.
-// 10 is a rather arbitrary guess on how many frames might be needed simultaneously
-var iteratorStack = make(map[uint64]frame, 10)
+var iteratorStack = make(map[uint64]frame)
 var iteratorStackMutex sync.Mutex
 
 // this is a global counter for creating call IDs

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -6,18 +6,18 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-// frame stores all Iterators for one contract
+// frame stores all Iterators for one contract call
 type frame []dbm.Iterator
 
-// iteratorStack contains one frame for each contract call, indexed by contract call ID.
-var iteratorStack = make(map[uint64]frame)
-var iteratorStackMutex sync.Mutex
+// iteratorFrames contains one frame for each contract call, indexed by contract call ID.
+var iteratorFrames = make(map[uint64]frame)
+var iteratorFramesMutex sync.Mutex
 
 // this is a global counter for creating call IDs
 var latestCallID uint64
 var latestCallIDMutex sync.Mutex
 
-// startCall is called at the beginning of a contract call to create a new frame on the iteratorStack.
+// startCall is called at the beginning of a contract call to create a new frame in iteratorFrames.
 // It updates latestCallID for generating a new call ID.
 func startCall() uint64 {
 	latestCallIDMutex.Lock()
@@ -30,15 +30,15 @@ func startCall() uint64 {
 // The result can be nil when the frame is not initialized,
 // i.e. when startCall() is called but no iterator is stored.
 func removeFrame(callID uint64) frame {
-	iteratorStackMutex.Lock()
-	defer iteratorStackMutex.Unlock()
+	iteratorFramesMutex.Lock()
+	defer iteratorFramesMutex.Unlock()
 
-	remove := iteratorStack[callID]
-	delete(iteratorStack, callID)
+	remove := iteratorFrames[callID]
+	delete(iteratorFrames, callID)
 	return remove
 }
 
-// endCall is called at the end of a contract call to remove one item from the IteratorStack
+// endCall is called at the end of a contract call to remove one item the iteratorFrames
 func endCall(callID uint64) {
 	// we pull removeFrame in another function so we don't hold the mutex while cleaning up the removed frame
 	remove := removeFrame(callID)
@@ -48,15 +48,15 @@ func endCall(callID uint64) {
 	}
 }
 
-// storeIterator will add this to the end of the latest stack and return a reference to it.
+// storeIterator will add this to the end of the frame for the given ID and return a reference to it.
 // We start counting with 1, so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
 func storeIterator(callID uint64, it dbm.Iterator) uint64 {
-	iteratorStackMutex.Lock()
-	defer iteratorStackMutex.Unlock()
+	iteratorFramesMutex.Lock()
+	defer iteratorFramesMutex.Unlock()
 
-	frame := append(iteratorStack[callID], it)
-	iteratorStack[callID] = frame
+	frame := append(iteratorFrames[callID], it)
+	iteratorFrames[callID] = frame
 	return uint64(len(frame))
 }
 
@@ -64,7 +64,7 @@ func storeIterator(callID uint64, it dbm.Iterator) uint64 {
 // We start counting with 1, in storeIterator so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
 func retrieveIterator(callID uint64, index uint64) dbm.Iterator {
-	iteratorStackMutex.Lock()
-	defer iteratorStackMutex.Unlock()
-	return iteratorStack[callID][index-1]
+	iteratorFramesMutex.Lock()
+	defer iteratorFramesMutex.Unlock()
+	return iteratorFrames[callID][index-1]
 }

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -70,5 +70,14 @@ func storeIterator(callID uint64, it dbm.Iterator) uint64 {
 func retrieveIterator(callID uint64, index uint64) dbm.Iterator {
 	iteratorFramesMutex.Lock()
 	defer iteratorFramesMutex.Unlock()
-	return iteratorFrames[callID][index-1]
+	myFrame := iteratorFrames[callID]
+	if myFrame == nil {
+		return nil
+	}
+	posInFrame := int(index) - 1
+	if posInFrame < 0 || posInFrame >= len(myFrame) {
+		// index out of range
+		return nil
+	}
+	return myFrame[posInFrame]
 }

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -55,9 +55,13 @@ func storeIterator(callID uint64, it dbm.Iterator) uint64 {
 	iteratorFramesMutex.Lock()
 	defer iteratorFramesMutex.Unlock()
 
-	frame := append(iteratorFrames[callID], it)
-	iteratorFrames[callID] = frame
-	return uint64(len(frame))
+	old_frame_len := len(iteratorFrames[callID])
+
+	// store at array position `old_frame_len`
+	iteratorFrames[callID] = append(iteratorFrames[callID], it)
+	new_index := old_frame_len + 1
+
+	return uint64(new_index)
 }
 
 // retrieveIterator will recover an iterator based on index. This ensures it will not be garbage collected.

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -26,10 +26,12 @@ func startCall() uint64 {
 	return latestCallID
 }
 
-func popFrame(callID uint64) frame {
+// removeFrame removes the frame with for the given call ID.
+// The result can be nil when the frame is not initialized,
+// i.e. when startCall() is called but no iterator is stored.
+func removeFrame(callID uint64) frame {
 	iteratorStackMutex.Lock()
 	defer iteratorStackMutex.Unlock()
-	// get the item from the stack
 
 	remove := iteratorStack[callID]
 	delete(iteratorStack, callID)
@@ -38,8 +40,8 @@ func popFrame(callID uint64) frame {
 
 // endCall is called at the end of a contract call to remove one item from the IteratorStack
 func endCall(callID uint64) {
-	// we pull popFrame in another function so we don't hold the mutex while cleaning up the popped frame
-	remove := popFrame(callID)
+	// we pull removeFrame in another function so we don't hold the mutex while cleaning up the removed frame
+	remove := removeFrame(callID)
 	// free all iterators in the frame when we release it
 	for _, iter := range remove {
 		iter.Close()

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -9,38 +9,38 @@ import (
 // frame stores all Iterators for one contract
 type frame []dbm.Iterator
 
-// iteratorStack contains one frame for each contract, indexed by a counter
+// iteratorStack contains one frame for each contract call, indexed by contract call ID.
 // 10 is a rather arbitrary guess on how many frames might be needed simultaneously
 var iteratorStack = make(map[uint64]frame, 10)
 var iteratorStackMutex sync.Mutex
 
-// this is a global counter when we create DBs
-var dbCounter uint64
-var dbCounterMutex sync.Mutex
+// this is a global counter for creating call IDs
+var latestCallID uint64
+var latestCallIDMutex sync.Mutex
 
-// startContract is called at the beginning of a contract runtime to create a new frame on the iteratorStack
-// updates dbCounter for an index
-func startContract() uint64 {
-	dbCounterMutex.Lock()
-	defer dbCounterMutex.Unlock()
-	dbCounter += 1
-	return dbCounter
+// startCall is called at the beginning of a contract call to create a new frame on the iteratorStack.
+// It updates latestCallID for generating a new call ID.
+func startCall() uint64 {
+	latestCallIDMutex.Lock()
+	defer latestCallIDMutex.Unlock()
+	latestCallID += 1
+	return latestCallID
 }
 
-func popFrame(counter uint64) frame {
+func popFrame(callID uint64) frame {
 	iteratorStackMutex.Lock()
 	defer iteratorStackMutex.Unlock()
 	// get the item from the stack
 
-	remove := iteratorStack[counter]
-	delete(iteratorStack, counter)
+	remove := iteratorStack[callID]
+	delete(iteratorStack, callID)
 	return remove
 }
 
-// endContract is called at the end of a contract runtime to remove one item from the IteratorStack
-func endContract(counter uint64) {
+// endCall is called at the end of a contract call to remove one item from the IteratorStack
+func endCall(callID uint64) {
 	// we pull popFrame in another function so we don't hold the mutex while cleaning up the popped frame
-	remove := popFrame(counter)
+	remove := popFrame(callID)
 	// free all iterators in the frame when we release it
 	for _, iter := range remove {
 		iter.Close()
@@ -50,20 +50,20 @@ func endContract(counter uint64) {
 // storeIterator will add this to the end of the latest stack and return a reference to it.
 // We start counting with 1, so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
-func storeIterator(dbCounter uint64, it dbm.Iterator) uint64 {
+func storeIterator(callID uint64, it dbm.Iterator) uint64 {
 	iteratorStackMutex.Lock()
 	defer iteratorStackMutex.Unlock()
 
-	frame := append(iteratorStack[dbCounter], it)
-	iteratorStack[dbCounter] = frame
+	frame := append(iteratorStack[callID], it)
+	iteratorStack[callID] = frame
 	return uint64(len(frame))
 }
 
 // retrieveIterator will recover an iterator based on index. This ensures it will not be garbage collected.
 // We start counting with 1, in storeIterator so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
-func retrieveIterator(dbCounter uint64, index uint64) dbm.Iterator {
+func retrieveIterator(callID uint64, index uint64) dbm.Iterator {
 	iteratorStackMutex.Lock()
 	defer iteratorStackMutex.Unlock()
-	return iteratorStack[dbCounter][index-1]
+	return iteratorStack[callID][index-1]
 }

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/CosmWasm/wasmvm/types"
+	dbm "github.com/tendermint/tm-db"
 )
 
 type queueData struct {
@@ -59,6 +60,35 @@ func setupQueueContractWithData(t *testing.T, cache Cache, values ...int) queueD
 
 func setupQueueContract(t *testing.T, cache Cache) queueData {
 	return setupQueueContractWithData(t, cache, 17, 22)
+}
+
+func TestStoreIterator(t *testing.T) {
+	callID1 := startCall()
+	callID2 := startCall()
+
+	store := dbm.NewMemDB()
+	var iter dbm.Iterator
+	var index uint64
+
+	iter, _ = store.Iterator(nil, nil)
+	index = storeIterator(callID1, iter)
+	require.Equal(t, uint64(1), index)
+	iter, _ = store.Iterator(nil, nil)
+	index = storeIterator(callID1, iter)
+	require.Equal(t, uint64(2), index)
+
+	iter, _ = store.Iterator(nil, nil)
+	index = storeIterator(callID2, iter)
+	require.Equal(t, uint64(1), index)
+	iter, _ = store.Iterator(nil, nil)
+	index = storeIterator(callID2, iter)
+	require.Equal(t, uint64(2), index)
+	iter, _ = store.Iterator(nil, nil)
+	index = storeIterator(callID2, iter)
+	require.Equal(t, uint64(3), index)
+
+	endCall(callID1)
+	endCall(callID2)
 }
 
 func TestQueueIterator(t *testing.T) {

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -129,7 +129,7 @@ func TestRetrieveIterator(t *testing.T) {
 	endCall(callID2)
 }
 
-func TestQueueIterator(t *testing.T) {
+func TestQueueIteratorSimple(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -91,6 +91,44 @@ func TestStoreIterator(t *testing.T) {
 	endCall(callID2)
 }
 
+func TestRetrieveIterator(t *testing.T) {
+	callID1 := startCall()
+	callID2 := startCall()
+
+	store := dbm.NewMemDB()
+	var iter dbm.Iterator
+
+	iter, _ = store.Iterator(nil, nil)
+	index11 := storeIterator(callID1, iter)
+	iter, _ = store.Iterator(nil, nil)
+	_ = storeIterator(callID1, iter)
+	iter, _ = store.Iterator(nil, nil)
+	_ = storeIterator(callID2, iter)
+	iter, _ = store.Iterator(nil, nil)
+	index22 := storeIterator(callID2, iter)
+	iter, _ = store.Iterator(nil, nil)
+	index23 := storeIterator(callID2, iter)
+
+	// Retrieve existing
+	iter = retrieveIterator(callID1, index11)
+	require.NotNil(t, iter)
+	iter = retrieveIterator(callID2, index22)
+	require.NotNil(t, iter)
+
+	// Retrieve non-existent index
+	iter = retrieveIterator(callID1, index23)
+	require.Nil(t, iter)
+	iter = retrieveIterator(callID1, uint64(0))
+	require.Nil(t, iter)
+
+	// Retrieve non-existent call ID
+	iter = retrieveIterator(callID1+1_234_567, index23)
+	require.Nil(t, iter)
+
+	endCall(callID1)
+	endCall(callID2)
+}
+
 func TestQueueIterator(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -97,7 +97,7 @@ func TestQueueIteratorRaces(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
-	assert.Equal(t, len(iteratorStack), 0)
+	assert.Equal(t, 0, len(iteratorFrames))
 
 	contract1 := setupQueueContractWithData(t, cache, 17, 22)
 	contract2 := setupQueueContractWithData(t, cache, 1, 19, 6, 35, 8)
@@ -143,6 +143,6 @@ func TestQueueIteratorRaces(t *testing.T) {
 	}
 	wg.Wait()
 
-	// when they finish, we should have popped everything off the stack
-	assert.Equal(t, len(iteratorStack), 0)
+	// when they finish, we should have removed all frames
+	assert.Equal(t, 0, len(iteratorFrames))
 }

--- a/api/lib.go
+++ b/api/lib.go
@@ -156,11 +156,10 @@ func Instantiate(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -197,11 +196,10 @@ func Execute(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -235,11 +233,10 @@ func Migrate(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -273,11 +270,10 @@ func Sudo(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -311,11 +307,10 @@ func Reply(
 	r := makeView(reply)
 	defer runtime.KeepAlive(reply)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -349,11 +344,10 @@ func Query(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -387,11 +381,10 @@ func IBCChannelOpen(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -425,11 +418,10 @@ func IBCChannelConnect(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -463,11 +455,10 @@ func IBCChannelClose(
 	m := makeView(msg)
 	defer runtime.KeepAlive(msg)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -501,11 +492,10 @@ func IBCPacketReceive(
 	pa := makeView(packet)
 	defer runtime.KeepAlive(packet)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -539,11 +529,10 @@ func IBCPacketAck(
 	ac := makeView(ack)
 	defer runtime.KeepAlive(ack)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
@@ -577,11 +566,10 @@ func IBCPacketTimeout(
 	pa := makeView(packet)
 	defer runtime.KeepAlive(packet)
 
-	// set up a new stack frame to handle iterators
-	counter := startContract()
-	defer endContract(counter)
+	callID := startCall()
+	defer endCall(callID)
 
-	dbState := buildDBState(store, counter)
+	dbState := buildDBState(store, callID)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)

--- a/libwasmvm/bindings.h
+++ b/libwasmvm/bindings.h
@@ -246,7 +246,10 @@ typedef struct U8SliceView {
 } U8SliceView;
 
 typedef struct iterator_t {
-  uint64_t db_counter;
+  /**
+   * An ID assigned to this contract call
+   */
+  uint64_t call_id;
   uint64_t iterator_index;
 } iterator_t;
 

--- a/libwasmvm/src/iterator.rs
+++ b/libwasmvm/src/iterator.rs
@@ -9,7 +9,8 @@ use crate::memory::UnmanagedVector;
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct iterator_t {
-    pub db_counter: u64,
+    /// An ID assigned to this contract call
+    pub call_id: u64,
     pub iterator_index: u64,
 }
 


### PR DESCRIPTION
Before this change, the size of a frame (number of iterators) was unbound. This could potentially exceed ressource limits before the gas limit is reached. With this PR, the number of iterators gets limited to 32k. From the tests I did, this is far more than what can be afforded by the gas limit. But better safe than sorry.