### PR TITLE
Format codebase using gofumpt

### DIFF
--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -310,8 +310,10 @@ func cNext(ref C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *
 
 /***** GoAPI *******/
 
-type HumanizeAddress func([]byte) (string, uint64, error)
-type CanonicalizeAddress func(string) ([]byte, uint64, error)
+type (
+	HumanizeAddress     func([]byte) (string, uint64, error)
+	CanonicalizeAddress func(string) ([]byte, uint64, error)
+)
 
 type GoAPI struct {
 	HumanAddress     HumanizeAddress

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	dbm "github.com/tendermint/tm-db"
 	"sync"
+
+	dbm "github.com/tendermint/tm-db"
 )
 
 // frame stores all Iterators for one contract

--- a/api/lib.go
+++ b/api/lib.go
@@ -13,15 +13,17 @@ import (
 )
 
 // Value types
-type cint = C.int
-type cbool = C.bool
-type cusize = C.size_t
-type cu8 = C.uint8_t
-type cu32 = C.uint32_t
-type cu64 = C.uint64_t
-type ci8 = C.int8_t
-type ci32 = C.int32_t
-type ci64 = C.int64_t
+type (
+	cint   = C.int
+	cbool  = C.bool
+	cusize = C.size_t
+	cu8    = C.uint8_t
+	cu32   = C.uint32_t
+	cu64   = C.uint64_t
+	ci8    = C.int8_t
+	ci32   = C.int32_t
+	ci64   = C.int64_t
+)
 
 // Pointers
 type cu8_ptr = *C.uint8_t

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/CosmWasm/wasmvm/types"
 )
 
-const TESTING_FEATURES = "staking,stargate,iterator"
-const TESTING_PRINT_DEBUG = false
-const TESTING_GAS_LIMIT = uint64(500_000_000_000) // ~0.5ms
-const TESTING_MEMORY_LIMIT = 32                   // MiB
-const TESTING_CACHE_SIZE = 100                    // MiB
+const (
+	TESTING_FEATURES     = "staking,stargate,iterator"
+	TESTING_PRINT_DEBUG  = false
+	TESTING_GAS_LIMIT    = uint64(500_000_000_000) // ~0.5ms
+	TESTING_MEMORY_LIMIT = 32                      // MiB
+	TESTING_CACHE_SIZE   = 100                     // MiB
+)
 
 func TestInitAndReleaseCache(t *testing.T) {
 	dataDir := "/foo"
@@ -116,7 +118,8 @@ func TestPinErrors(t *testing.T) {
 	unknownChecksum := []byte{
 		0x72, 0x2c, 0x8c, 0x99, 0x3f, 0xd7, 0x5a, 0x76, 0x27, 0xd6, 0x9e, 0xd9, 0x41, 0x34,
 		0x4f, 0xe2, 0xa1, 0x42, 0x3a, 0x3e, 0x75, 0xef, 0xd3, 0xe6, 0x77, 0x8a, 0x14, 0x28,
-		0x84, 0x22, 0x71, 0x04}
+		0x84, 0x22, 0x71, 0x04,
+	}
 	err = Pin(cache, unknownChecksum)
 	require.ErrorContains(t, err, "No such file or directory")
 }
@@ -921,7 +924,7 @@ func TestCustomReflectQuerier(t *testing.T) {
 	querier = Querier(innerQuerier)
 
 	// make a valid query to the other address
-	var queryMsg = QueryMsg{
+	queryMsg := QueryMsg{
 		Capitalized: &CapitalizedQuery{
 			Text: "small Frys :)",
 		},

--- a/api/mocks.go
+++ b/api/mocks.go
@@ -235,7 +235,6 @@ func (g *mockGasMeter) ConsumeGas(amount Gas, descriptor string) {
 	if g.consumed > g.limit {
 		panic(ErrorOutOfGas{descriptor})
 	}
-
 }
 
 /*** Mock KVStore ****/
@@ -446,7 +445,7 @@ func NewBankQuerier(balances map[string]types.Coins) BankQuerier {
 func (q BankQuerier) Query(request *types.BankQuery) ([]byte, error) {
 	if request.Balance != nil {
 		denom := request.Balance.Denom
-		var coin = types.NewCoin(0, denom)
+		coin := types.NewCoin(0, denom)
 		for _, c := range q.Balances[request.Balance.Address] {
 			if c.Denom == denom {
 				coin = c

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"fmt"
-	wasmvm "github.com/CosmWasm/wasmvm"
 	"io/ioutil"
 	"os"
+
+	wasmvm "github.com/CosmWasm/wasmvm"
 )
 
-const SUPPORTED_FEATURES = "staking"
-const PRINT_DEBUG = true
-const MEMORY_LIMIT = 32 // MiB
-const CACHE_SIZE = 100  // MiB
+const (
+	SUPPORTED_FEATURES = "staking"
+	PRINT_DEBUG        = true
+	MEMORY_LIMIT       = 32  // MiB
+	CACHE_SIZE         = 100 // MiB
+)
 
 // This is just a demo to ensure we can compile a static go binary
 func main() {
@@ -22,7 +25,7 @@ func main() {
 	}
 	fmt.Println("Loaded!")
 
-	os.MkdirAll("tmp", 0755)
+	os.MkdirAll("tmp", 0o755)
 	vm, err := wasmvm.NewVM("tmp", SUPPORTED_FEATURES, MEMORY_LIMIT, PRINT_DEBUG, CACHE_SIZE)
 	if err != nil {
 		panic(err)

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -130,9 +130,9 @@ func TestIBCHandshake(t *testing.T) {
 	require.Equal(t, 1, len(res.Messages))
 
 	// check for the expected custom event
-	expected_events := []types.Event{types.Event{
+	expected_events := []types.Event{{
 		Type: "ibc",
-		Attributes: []types.EventAttribute{types.EventAttribute{
+		Attributes: []types.EventAttribute{{
 			Key:   "channel",
 			Value: "connect",
 		}},
@@ -264,9 +264,9 @@ func TestIBCPacketDispatch(t *testing.T) {
 	require.Equal(t, "invalid packet: cosmwasm_std::addresses::Addr not found", ack2.Err)
 
 	// check for the expected custom event
-	expected_events := []types.Event{types.Event{
+	expected_events := []types.Event{{
 		Type: "ibc",
-		Attributes: []types.EventAttribute{types.EventAttribute{
+		Attributes: []types.EventAttribute{{
 			Key:   "packet",
 			Value: "receive",
 		}},

--- a/lib_test.go
+++ b/lib_test.go
@@ -1,20 +1,23 @@
 package cosmwasm
 
 import (
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/CosmWasm/wasmvm/api"
 	"github.com/CosmWasm/wasmvm/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
-const TESTING_FEATURES = "staking,stargate,iterator"
-const TESTING_PRINT_DEBUG = false
-const TESTING_GAS_LIMIT = uint64(500_000_000_000) // ~0.5ms
-const TESTING_MEMORY_LIMIT = 32                   // MiB
-const TESTING_CACHE_SIZE = 100                    // MiB
+const (
+	TESTING_FEATURES     = "staking,stargate,iterator"
+	TESTING_PRINT_DEBUG  = false
+	TESTING_GAS_LIMIT    = uint64(500_000_000_000) // ~0.5ms
+	TESTING_MEMORY_LIMIT = 32                      // MiB
+	TESTING_CACHE_SIZE   = 100                     // MiB
+)
 
 const HACKATOM_TEST_CONTRACT = "./api/testdata/hackatom.wasm"
 

--- a/types/queries_test.go
+++ b/types/queries_test.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestDelegationWithEmptyArray(t *testing.T) {
@@ -111,5 +112,4 @@ func TestQueryResponseWithEmptyData(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
Run `gofumpt -w -l .`

Closes #318

Thank you, @faddat 