### PR TITLE
Add ibc v3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ lib*.a
 /demo
 tmp
 a.out
+
+# IDE stuff
+.idea
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/*.rs.bk
 *.iml
 .idea
+.vscode
 
 # no static libraries (35MB+)
 lib*.a
@@ -11,7 +12,3 @@ lib*.a
 /demo
 tmp
 a.out
-
-# IDE stuff
-.idea
-.vscode

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -112,12 +112,14 @@ func TestIBCHandshake(t *testing.T) {
 	env = api.MockEnv()
 	// fails on bad version
 	openMsg := api.MockIBCChannelOpenInit(CHANNEL_ID, types.Ordered, "random-garbage")
-	_, err = vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	_, _, err = vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.Error(t, err)
 	// passes on good version
 	openMsg = api.MockIBCChannelOpenInit(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	_, err = vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	ores, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	// also nil
+	require.Nil(t, ores)
 
 	// channel connect
 	gasMeter3 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
@@ -180,8 +182,9 @@ func TestIBCPacketDispatch(t *testing.T) {
 	gasMeter2 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
 	store.SetGasMeter(gasMeter2)
 	openMsg := api.MockIBCChannelOpenInit(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	_, err = vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	ores, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.Nil(t, ores)
 
 	// channel connect
 	gasMeter3 := api.NewMockGasMeter(TESTING_GAS_LIMIT)

--- a/lib.go
+++ b/lib.go
@@ -388,35 +388,35 @@ func (vm *VM) IBCChannelOpen(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (uint64, error) {
+) (*types.IBCV3ChannelOpenResponse, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
 	msgBin, err := json.Marshal(msg)
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
 	data, gasUsed, err := api.IBCChannelOpen(vm.cache, checksum, envBin, msgBin, &gasMeter, store, &goapi, &querier, gasLimit, vm.printDebug)
 	if err != nil {
-		return gasUsed, err
+		return nil, gasUsed, err
 	}
 
 	gasForDeserialization := deserCost.Mul(uint64(len(data))).Floor()
 	if gasLimit < gasForDeserialization+gasUsed {
-		return gasUsed, fmt.Errorf("Insufficient gas left to deserialize contract execution result (%d bytes)", len(data))
+		return nil, gasUsed, fmt.Errorf("insufficient gas left to deserialize contract execution result (%d bytes)", len(data))
 	}
 	gasUsed += gasForDeserialization
 
 	var resp types.IBCChannelOpenResult
 	err = json.Unmarshal(data, &resp)
 	if err != nil {
-		return gasUsed, err
+		return nil, gasUsed, err
 	}
 	if resp.Err != "" {
-		return gasUsed, fmt.Errorf("%s", resp.Err)
+		return nil, gasUsed, fmt.Errorf("%s", resp.Err)
 	}
-	return gasUsed, nil
+	return resp.Ok, gasUsed, nil
 }
 
 // IBCChannelConnect is available on IBC-enabled contracts and is a hook to call into

--- a/lib.go
+++ b/lib.go
@@ -388,7 +388,7 @@ func (vm *VM) IBCChannelOpen(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.IBCV3ChannelOpenResponse, uint64, error) {
+) (*types.IBC3ChannelOpenResponse, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err

--- a/types/ibc.go
+++ b/types/ibc.go
@@ -133,16 +133,19 @@ func (m *IBCCloseConfirm) ToMsg() IBCChannelCloseMsg {
 }
 
 type IBCPacketReceiveMsg struct {
-	Packet IBCPacket `json:"packet"`
+	Packet  IBCPacket `json:"packet"`
+	Relayer string    `json:"relayer,omitempty"`
 }
 
 type IBCPacketAckMsg struct {
 	Acknowledgement IBCAcknowledgement `json:"acknowledgement"`
 	OriginalPacket  IBCPacket          `json:"original_packet"`
+	Relayer         string             `json:"relayer,omitempty"`
 }
 
 type IBCPacketTimeoutMsg struct {
-	Packet IBCPacket `json:"packet"`
+	Packet  IBCPacket `json:"packet"`
+	Relayer string    `json:"relayer,omitempty"`
 }
 
 // TODO: test what the sdk Order.String() represents and how to parse back
@@ -192,10 +195,17 @@ type IBCPacket struct {
 
 // IBCChannelOpenResult is the raw response from the ibc_channel_open call.
 // This is mirrors Rust's ContractResult<()>.
-// We just check if Err == "" to see if this is success (no other data on success)
+// Check if Err == "" to see if this is success
+// On Success, IBCV3ChannelOpenResponse *may* be set if the contract is ibcv3 compatible and wishes to
+// define a custom version in the handshake.
 type IBCChannelOpenResult struct {
-	Ok  *struct{} `json:"ok,omitempty"`
-	Err string    `json:"error,omitempty"`
+	Ok  *IBCV3ChannelOpenResponse `json:"ok,omitempty"`
+	Err string                    `json:"error,omitempty"`
+}
+
+// IBCV3ChannelOpenResponse is version negotiation data for the handshake
+type IBCV3ChannelOpenResponse struct {
+	Version string `json:"version"`
 }
 
 // This is the return value for the majority of the ibc handlers.

--- a/types/ibc.go
+++ b/types/ibc.go
@@ -134,18 +134,18 @@ func (m *IBCCloseConfirm) ToMsg() IBCChannelCloseMsg {
 
 type IBCPacketReceiveMsg struct {
 	Packet  IBCPacket `json:"packet"`
-	Relayer string    `json:"relayer,omitempty"`
+	Relayer string    `json:"relayer"`
 }
 
 type IBCPacketAckMsg struct {
 	Acknowledgement IBCAcknowledgement `json:"acknowledgement"`
 	OriginalPacket  IBCPacket          `json:"original_packet"`
-	Relayer         string             `json:"relayer,omitempty"`
+	Relayer         string             `json:"relayer"`
 }
 
 type IBCPacketTimeoutMsg struct {
 	Packet  IBCPacket `json:"packet"`
-	Relayer string    `json:"relayer,omitempty"`
+	Relayer string    `json:"relayer"`
 }
 
 // TODO: test what the sdk Order.String() represents and how to parse back
@@ -199,12 +199,12 @@ type IBCPacket struct {
 // On Success, IBCV3ChannelOpenResponse *may* be set if the contract is ibcv3 compatible and wishes to
 // define a custom version in the handshake.
 type IBCChannelOpenResult struct {
-	Ok  *IBCV3ChannelOpenResponse `json:"ok,omitempty"`
-	Err string                    `json:"error,omitempty"`
+	Ok  *IBC3ChannelOpenResponse `json:"ok,omitempty"`
+	Err string                   `json:"error,omitempty"`
 }
 
-// IBCV3ChannelOpenResponse is version negotiation data for the handshake
-type IBCV3ChannelOpenResponse struct {
+// IBC3ChannelOpenResponse is version negotiation data for the handshake
+type IBC3ChannelOpenResponse struct {
 	Version string `json:"version"`
 }
 


### PR DESCRIPTION
This updates the Go types to match changes in https://github.com/CosmWasm/cosmwasm/pull/1302

Only merge once that will be merged. Doesn't require the library to be updated first, just that we agree on the structs. This is backwards compatible. 