### PR TITLE
Add query for the total supply of a coin

### DIFF
--- a/types/queries.go
+++ b/types/queries.go
@@ -90,8 +90,18 @@ type QueryRequest struct {
 }
 
 type BankQuery struct {
+	Supply      *SupplyQuery      `json:"supply,omitempty"`
 	Balance     *BalanceQuery     `json:"balance,omitempty"`
 	AllBalances *AllBalancesQuery `json:"all_balances,omitempty"`
+}
+
+type SupplyQuery struct {
+	Denom string `json:"denom"`
+}
+
+// SupplyResponse is the expected response to SupplyQuery
+type SupplyResponse struct {
+	Amount Coin `json:"amount"`
 }
 
 type BalanceQuery struct {


### PR DESCRIPTION
currently it is not possible to query the total supply of a native SDK coin. this is something that protocols often need to do, especially that now contract are able to mint native coins thanks to the `tokenfactory` module. this PR adds the binding for this query type.

see also:
* https://github.com/CosmWasm/wasmd/pull/903
* https://github.com/CosmWasm/cosmwasm/pull/1356