### PR TITLE
Add static build for macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,6 +335,9 @@ jobs:
           name: Build static library for Alpine
           command: make release-build-alpine
       - run:
+          name: Build static library for MacOS
+          command: make release-build-macos-static
+      - run:
           name: Debug build results
           command: ls -l ./internal/api
       - run:
@@ -343,6 +346,7 @@ jobs:
             mkdir artifacts
             cp ./internal/api/libwasmvm_muslc.a artifacts/libwasmvm_muslc.x86_64.a
             cp ./internal/api/libwasmvm_muslc.aarch64.a artifacts/libwasmvm_muslc.aarch64.a
+            cp ./internal/api/static/libwasmvm_darwin.a artifacts/libwasmvm_darwin.a
       - run:
           name: Create checksums
           working_directory: artifacts

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,17 @@ release-build-macos:
 	cp libwasmvm/artifacts/libwasmvm.dylib internal/api
 	make update-bindings
 
+# Creates a release build in a containerized build environment of the static library for macOS (.a)
+release-build-macos-static:
+	rm -rf libwasmvm/target/x86_64-apple-darwin/release
+	rm -rf libwasmvm/target/aarch64-apple-darwin/release
+	docker run --rm -u $(USER_ID):$(USER_GROUP) \
+		-v $(shell pwd)/libwasmvm:/code \
+		-v $(shell pwd)/builders/guest/build_macos_static.sh:/usr/local/bin/build_macos_static.sh \
+		$(BUILDERS_PREFIX)-cross build_macos_static.sh
+	cp libwasmvm/artifacts/libwasmvm_darwin.a internal/api/static/libwasmvm_darwin.a
+	make update-bindings
+
 # Creates a release build in a containerized build environment of the shared library for Windows (.dll)
 release-build-windows:
 	rm -rf libwasmvm/target/release

--- a/builders/guest/build_macos_static.sh
+++ b/builders/guest/build_macos_static.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# ref: https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html
+export PATH="/opt/osxcross/target/bin:$PATH"
+export LIBZ_SYS_STATIC=1
+
+# See https://github.com/CosmWasm/wasmvm/issues/222#issuecomment-880616953 for two approaches to
+# enable stripping through cargo (if that is desired).
+
+echo "Starting aarch64-apple-darwin build"
+export CC=aarch64-apple-darwin20.4-clang
+export CXX=aarch64-apple-darwin20.4-clang++
+cargo build --release --target aarch64-apple-darwin --example wasmvmstatic
+
+echo "Starting x86_64-apple-darwin build"
+export CC=o64-clang
+export CXX=o64-clang++
+cargo build --release --target x86_64-apple-darwin --example wasmvmstatic
+
+# Create a universal library with both archs
+lipo -output artifacts/libwasmvm_darwin.a -create \
+  target/x86_64-apple-darwin/release/examples/libwasmvmstatic.a \
+  target/aarch64-apple-darwin/release/examples/libwasmvmstatic.a

--- a/builders/guest/build_muslc.sh
+++ b/builders/guest/build_muslc.sh
@@ -6,11 +6,11 @@ set -e # Note we are not using bash here but the Alpine default shell
 
 echo "Starting aarch64-unknown-linux-musl build"
 export CC=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-cargo build --release --target aarch64-unknown-linux-musl --example muslc
+cargo build --release --target aarch64-unknown-linux-musl --example wasmvmstatic
 unset CC
 
 echo "Starting x86_64-unknown-linux-musl build"
-cargo build --release --target x86_64-unknown-linux-musl --example muslc
+cargo build --release --target x86_64-unknown-linux-musl --example wasmvmstatic
 
-cp target/aarch64-unknown-linux-musl/release/examples/libmuslc.a artifacts/libwasmvm_muslc.aarch64.a
-cp target/x86_64-unknown-linux-musl/release/examples/libmuslc.a artifacts/libwasmvm_muslc.a
+cp target/aarch64-unknown-linux-musl/release/examples/libwasmvmstatic.a artifacts/libwasmvm_muslc.aarch64.a
+cp target/x86_64-unknown-linux-musl/release/examples/libwasmvmstatic.a artifacts/libwasmvm_muslc.a

--- a/internal/api/link_mac.go
+++ b/internal/api/link_mac.go
@@ -1,4 +1,4 @@
-//go:build darwin && !sys_wasmvm
+//go:build darwin && !static_wasm && !sys_wasmvm
 
 package api
 

--- a/internal/api/link_mac_static.go
+++ b/internal/api/link_mac_static.go
@@ -1,0 +1,6 @@
+//go:build darwin && static_wasm && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -L${SRCDIR}/static -lwasmvm_darwin
+import "C"

--- a/libwasmvm/Cargo.toml
+++ b/libwasmvm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 # the example is to allow us to compile a muslc static lib with the same codebase as we compile the
 # normal dynamic libs (best workaround I could find to override crate-type on the command line)
 [[example]]
-name = "muslc"
+name = "wasmvmstatic"
 path = "src/lib.rs"
 crate-type = ["staticlib"]
 


### PR DESCRIPTION
This PR adds support for building static wasmvm (universal) for `darwin`.

Here at [Nibiru](https://github.com/NibiruChain) we would like to provide binaries for both `linux` and `darwin`, without requesting users to manually install libraries. We are aware that going fully static on `macOS` is hard (if not impossible), and we still need to link dynamically to system libraries, but at least `libwasmvm` can be statically linked to our executable.

With this changes, we can use a simple [goreleaser config](https://github.com/NibiruChain/nibiru/blob/93f07dc8cce116365f777b36fe13b7ac437a58d3/.goreleaser.yml) and [goreleaser-cross](https://github.com/goreleaser/goreleaser-cross) to build binaries to all platforms.