### PR TITLE
feat: QOL GetDefaultFeatures

### DIFF
--- a/internal/api/lib.go
+++ b/internal/api/lib.go
@@ -58,6 +58,10 @@ func ReleaseCache(cache Cache) {
 	C.release_cache(cache.ptr)
 }
 
+func GetDefaultFeatures() string {
+	return "cosmwasm_1_1,cosmwasm_1_2"
+}
+
 func StoreCode(cache Cache, wasm []byte) ([]byte, error) {
 	w := makeView(wasm)
 	defer runtime.KeepAlive(wasm)

--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -15,8 +15,9 @@ import (
 	"github.com/CosmWasm/wasmvm/types"
 )
 
+var TESTING_FEATURES = "staking,stargate,iterator," + GetDefaultFeatures()
+
 const (
-	TESTING_FEATURES     = "staking,stargate,iterator,cosmwasm_1_1,cosmwasm_1_2"
 	TESTING_PRINT_DEBUG  = false
 	TESTING_GAS_LIMIT    = uint64(500_000_000_000) // ~0.5ms
 	TESTING_MEMORY_LIMIT = 32                      // MiB

--- a/lib.go
+++ b/lib.go
@@ -36,6 +36,12 @@ func NewVM(dataDir string, supportedFeatures string, memoryLimit uint32, printDe
 	return &VM{cache: cache, printDebug: printDebug}, nil
 }
 
+// GetDefaultFeatures is called app.go to auto enable new features
+// on wasmvm upgrade.
+func GetDefaultFeatures() string {
+	return "cosmwasm_1_1,cosmwasm_1_2"
+}
+
 // Cleanup should be called when no longer using this to free resources on the rust-side
 func (vm *VM) Cleanup() {
 	api.ReleaseCache(vm.cache)

--- a/lib.go
+++ b/lib.go
@@ -39,7 +39,7 @@ func NewVM(dataDir string, supportedFeatures string, memoryLimit uint32, printDe
 // GetDefaultFeatures is called app.go to auto enable new features
 // on wasmvm upgrade.
 func GetDefaultFeatures() string {
-	return "cosmwasm_1_1,cosmwasm_1_2"
+	return api.GetDefaultFeatures()
 }
 
 // Cleanup should be called when no longer using this to free resources on the rust-side


### PR DESCRIPTION
# Feature
It would be nice to have `wasmvm.GetDefaultFeatures()` to return the default features. This is also used in the internal test.

# Reason
When upgrading, its common to forget this ( We did for juno v14). It would be nice for this to be upstream to ensure its handled when chains upgrade their wasmvm automatically for future 1.3+ wasmvm new features

# Before & After
app.go
![image](https://user-images.githubusercontent.com/31943163/229636993-aab41988-10ab-4a36-b80e-2413ed0c77b3.png)

