### PR TITLE
Add `MsgFundCommunityPool` to the Distribution Msgs

### DIFF
--- a/types/msg.go
+++ b/types/msg.go
@@ -248,6 +248,7 @@ type RedelegateMsg struct {
 type DistributionMsg struct {
 	SetWithdrawAddress      *SetWithdrawAddressMsg      `json:"set_withdraw_address,omitempty"`
 	WithdrawDelegatorReward *WithdrawDelegatorRewardMsg `json:"withdraw_delegator_reward,omitempty"`
+	FundCommunityPool       *FundCommunityPoolMsg       `json:"fund_community_pool",omitempty"`
 }
 
 // SetWithdrawAddressMsg is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37).
@@ -262,6 +263,14 @@ type SetWithdrawAddressMsg struct {
 type WithdrawDelegatorRewardMsg struct {
 	// Validator contains `validator_address` of a MsgWithdrawDelegatorReward
 	Validator string `json:"validator"`
+}
+
+// FundCommunityPoolMsg is translated to a [MsgFundCommunityPool](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#LL69C1-L76C2).
+type FundCommunityPoolMsg struct {
+	// Amount is the list of coins to be send to the community pool
+	Amount     Coins  `json:"amount"`
+	// Depositor is the funding account
+	Depositor  string `json:"depositor"`
 }
 
 // StargateMsg is encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).

--- a/types/msg.go
+++ b/types/msg.go
@@ -269,7 +269,7 @@ type WithdrawDelegatorRewardMsg struct {
 // `depositor` is automatically filled with the current contract's address
 type FundCommunityPoolMsg struct {
 	// Amount is the list of coins to be send to the community pool
-	Amount     Coins  `json:"amount"`
+	Amount Coins `json:"amount"`
 }
 
 // StargateMsg is encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).

--- a/types/msg.go
+++ b/types/msg.go
@@ -266,11 +266,10 @@ type WithdrawDelegatorRewardMsg struct {
 }
 
 // FundCommunityPoolMsg is translated to a [MsgFundCommunityPool](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#LL69C1-L76C2).
+// `depositor` is automatically filled with the current contract's address
 type FundCommunityPoolMsg struct {
 	// Amount is the list of coins to be send to the community pool
 	Amount     Coins  `json:"amount"`
-	// Depositor is the funding account
-	Depositor  string `json:"depositor"`
 }
 
 // StargateMsg is encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -107,3 +107,14 @@ func TestGovMsgVoteWeightedSerialization(t *testing.T) {
 		{Abstain, "0.5"},
 	}, msg.VoteWeighted.Options)
 }
+
+func TestMsgFundCommunityPoolSerialization(t *testing.T) {
+	document := []byte(`{"fund_community_pool":{"amount":[{"amount":"300","denom":"adenom"},{"amount":"400","denom":"bdenom"}],"depositor":"generousone"}}`)
+	
+	var msg DistributionMsg
+	err := json.Unmarshal(document, &msg)
+	require.NoError(t, err)
+	
+	require.Equal(t, Coins{{"adenom", "300"},{"bdenom", "400"}}, msg.FundCommunityPool.Amount)
+	require.Equal(t, "generousone", msg.FundCommunityPool.Depositor)
+}

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -109,12 +109,11 @@ func TestGovMsgVoteWeightedSerialization(t *testing.T) {
 }
 
 func TestMsgFundCommunityPoolSerialization(t *testing.T) {
-	document := []byte(`{"fund_community_pool":{"amount":[{"amount":"300","denom":"adenom"},{"amount":"400","denom":"bdenom"}],"depositor":"generousone"}}`)
+	document := []byte(`{"fund_community_pool":{"amount":[{"amount":"300","denom":"adenom"},{"amount":"400","denom":"bdenom"}]}}`)
 	
 	var msg DistributionMsg
 	err := json.Unmarshal(document, &msg)
 	require.NoError(t, err)
 	
 	require.Equal(t, Coins{{"adenom", "300"},{"bdenom", "400"}}, msg.FundCommunityPool.Amount)
-	require.Equal(t, "generousone", msg.FundCommunityPool.Depositor)
 }

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -110,10 +110,10 @@ func TestGovMsgVoteWeightedSerialization(t *testing.T) {
 
 func TestMsgFundCommunityPoolSerialization(t *testing.T) {
 	document := []byte(`{"fund_community_pool":{"amount":[{"amount":"300","denom":"adenom"},{"amount":"400","denom":"bdenom"}]}}`)
-	
+
 	var msg DistributionMsg
 	err := json.Unmarshal(document, &msg)
 	require.NoError(t, err)
-	
-	require.Equal(t, Coins{{"adenom", "300"},{"bdenom", "400"}}, msg.FundCommunityPool.Amount)
+
+	require.Equal(t, Coins{{"adenom", "300"}, {"bdenom", "400"}}, msg.FundCommunityPool.Amount)
 }


### PR DESCRIPTION
Having the `MsgFundCommunityPool` available from within smart contracts is a "hot" feature in Terra Classic. I hereby politely ask you to add this Msg to the list of valid wasmvm types. Changes include:

- added `MsgFundCommunityPool` to wasmvmtypes
- added serialization test
- will add corresponding PRs for wasmd and cosmwasm::std

See also the following issues:

- https://github.com/classic-terra/core/issues/288
- https://github.com/CosmWasm/cosmwasm/issues/1741