### PR TITLE
Differentiate between contract and system error

### DIFF
--- a/ibc_test.go
+++ b/ibc_test.go
@@ -105,8 +105,10 @@ func TestIBCHandshake(t *testing.T) {
 	init_msg := IBCInstantiateMsg{
 		ReflectCodeID: REFLECT_ID,
 	}
-	ires, _, err := vm.Instantiate(checksum, env, info, toBytes(t, init_msg), store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err := vm.Instantiate(checksum, env, info, toBytes(t, init_msg), store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	assert.NotNil(t, i.Ok)
+	ires := i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// channel open
@@ -114,8 +116,10 @@ func TestIBCHandshake(t *testing.T) {
 	store.SetGasMeter(gasMeter2)
 	env = api.MockEnv()
 	openMsg := api.MockIBCChannelOpenInit(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	ores, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	o, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, o.Ok)
+	ores := o.Ok
 	require.Equal(t, &types.IBC3ChannelOpenResponse{Version: "ibc-reflect-v1"}, ores)
 
 	// channel connect
@@ -124,8 +128,10 @@ func TestIBCHandshake(t *testing.T) {
 	env = api.MockEnv()
 	// completes and dispatches message to create reflect contract
 	connectMsg := api.MockIBCChannelConnectAck(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	res, _, err := vm.IBCChannelConnect(checksum, env, connectMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	conn, _, err := vm.IBCChannelConnect(checksum, env, connectMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, conn.Ok)
+	res := conn.Ok
 	require.Equal(t, 1, len(res.Messages))
 
 	// check for the expected custom event
@@ -179,8 +185,10 @@ func TestIBCPacketDispatch(t *testing.T) {
 	gasMeter2 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
 	store.SetGasMeter(gasMeter2)
 	openMsg := api.MockIBCChannelOpenInit(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	ores, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	o, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, o.Ok)
+	ores := o.Ok
 	require.Equal(t, &types.IBC3ChannelOpenResponse{Version: "ibc-reflect-v1"}, ores)
 
 	// channel connect
@@ -188,8 +196,10 @@ func TestIBCPacketDispatch(t *testing.T) {
 	store.SetGasMeter(gasMeter3)
 	// completes and dispatches message to create reflect contract
 	connectMsg := api.MockIBCChannelConnectAck(CHANNEL_ID, types.Ordered, IBC_VERSION)
-	res, _, err := vm.IBCChannelConnect(checksum, env, connectMsg, store, *goapi, querier, gasMeter3, TESTING_GAS_LIMIT, deserCost)
+	conn, _, err := vm.IBCChannelConnect(checksum, env, connectMsg, store, *goapi, querier, gasMeter3, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, conn.Ok)
+	res := conn.Ok
 	require.Equal(t, 1, len(res.Messages))
 	id := res.Messages[0].ID
 
@@ -220,8 +230,10 @@ func TestIBCPacketDispatch(t *testing.T) {
 	queryMsg := IBCQueryMsg{
 		ListAccounts: &struct{}{},
 	}
-	qres, _, err := vm.Query(checksum, env, toBytes(t, queryMsg), store, *goapi, querier, gasMeter4, TESTING_GAS_LIMIT, deserCost)
+	q, _, err := vm.Query(checksum, env, toBytes(t, queryMsg), store, *goapi, querier, gasMeter4, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, q.Ok)
+	qres := q.Ok
 	var accounts ListAccountsResponse
 	err = json.Unmarshal(qres, &accounts)
 	require.NoError(t, err)

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -108,8 +108,8 @@ func TestIBCHandshake(t *testing.T) {
 	i, _, err := vm.Instantiate(checksum, env, info, toBytes(t, init_msg), store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	assert.NotNil(t, i.Ok)
-	ires := i.Ok
-	require.Equal(t, 0, len(ires.Messages))
+	iResponse := i.Ok
+	require.Equal(t, 0, len(iResponse.Messages))
 
 	// channel open
 	gasMeter2 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
@@ -119,8 +119,8 @@ func TestIBCHandshake(t *testing.T) {
 	o, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	require.NotNil(t, o.Ok)
-	ores := o.Ok
-	require.Equal(t, &types.IBC3ChannelOpenResponse{Version: "ibc-reflect-v1"}, ores)
+	oResponse := o.Ok
+	require.Equal(t, &types.IBC3ChannelOpenResponse{Version: "ibc-reflect-v1"}, oResponse)
 
 	// channel connect
 	gasMeter3 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
@@ -131,8 +131,8 @@ func TestIBCHandshake(t *testing.T) {
 	conn, _, err := vm.IBCChannelConnect(checksum, env, connectMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	require.NotNil(t, conn.Ok)
-	res := conn.Ok
-	require.Equal(t, 1, len(res.Messages))
+	connResponse := conn.Ok
+	require.Equal(t, 1, len(connResponse.Messages))
 
 	// check for the expected custom event
 	expected_events := []types.Event{{
@@ -142,10 +142,10 @@ func TestIBCHandshake(t *testing.T) {
 			Value: "connect",
 		}},
 	}}
-	require.Equal(t, expected_events, res.Events)
+	require.Equal(t, expected_events, connResponse.Events)
 
 	// make sure it read the balance properly and we got 250 atoms
-	dispatch := res.Messages[0].Msg
+	dispatch := connResponse.Messages[0].Msg
 	require.NotNil(t, dispatch.Wasm, "%#v", dispatch)
 	require.NotNil(t, dispatch.Wasm.Instantiate, "%#v", dispatch)
 	init := dispatch.Wasm.Instantiate
@@ -188,8 +188,8 @@ func TestIBCPacketDispatch(t *testing.T) {
 	o, _, err := vm.IBCChannelOpen(checksum, env, openMsg, store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	require.NotNil(t, o.Ok)
-	ores := o.Ok
-	require.Equal(t, &types.IBC3ChannelOpenResponse{Version: "ibc-reflect-v1"}, ores)
+	oResponse := o.Ok
+	require.Equal(t, &types.IBC3ChannelOpenResponse{Version: "ibc-reflect-v1"}, oResponse)
 
 	// channel connect
 	gasMeter3 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
@@ -199,9 +199,9 @@ func TestIBCPacketDispatch(t *testing.T) {
 	conn, _, err := vm.IBCChannelConnect(checksum, env, connectMsg, store, *goapi, querier, gasMeter3, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	require.NotNil(t, conn.Ok)
-	res := conn.Ok
-	require.Equal(t, 1, len(res.Messages))
-	id := res.Messages[0].ID
+	connResponse := conn.Ok
+	require.Equal(t, 1, len(connResponse.Messages))
+	id := connResponse.Messages[0].ID
 
 	// mock reflect init callback (to store address)
 	gasMeter4 := api.NewMockGasMeter(TESTING_GAS_LIMIT)
@@ -233,9 +233,9 @@ func TestIBCPacketDispatch(t *testing.T) {
 	q, _, err := vm.Query(checksum, env, toBytes(t, queryMsg), store, *goapi, querier, gasMeter4, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	require.NotNil(t, q.Ok)
-	qres := q.Ok
+	qResponse := q.Ok
 	var accounts ListAccountsResponse
-	err = json.Unmarshal(qres, &accounts)
+	err = json.Unmarshal(qResponse, &accounts)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(accounts.Accounts))
 	require.Equal(t, CHANNEL_ID, accounts.Accounts[0].ChannelID)
@@ -258,11 +258,11 @@ func TestIBCPacketDispatch(t *testing.T) {
 	pr, _, err := vm.IBCPacketReceive(checksum, env, msg, store, *goapi, querier, gasMeter5, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	assert.NotNil(t, pr.Ok)
-	pres := pr.Ok
+	prResponse := pr.Ok
 
 	// assert app-level success
 	var ack AcknowledgeDispatch
-	err = json.Unmarshal(pres.Acknowledgement, &ack)
+	err = json.Unmarshal(prResponse.Acknowledgement, &ack)
 	require.NoError(t, err)
 	require.Empty(t, ack.Err)
 
@@ -271,10 +271,10 @@ func TestIBCPacketDispatch(t *testing.T) {
 	pr2, _, err := vm.IBCPacketReceive(checksum, env, msg2, store, *goapi, querier, gasMeter5, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
 	assert.NotNil(t, pr.Ok)
-	pres2 := pr2.Ok
+	prResponse2 := pr2.Ok
 	// assert app-level failure
 	var ack2 AcknowledgeDispatch
-	err = json.Unmarshal(pres2.Acknowledgement, &ack2)
+	err = json.Unmarshal(prResponse2.Acknowledgement, &ack2)
 	require.NoError(t, err)
 	require.Equal(t, "invalid packet: cosmwasm_std::addresses::Addr not found", ack2.Err)
 
@@ -286,7 +286,7 @@ func TestIBCPacketDispatch(t *testing.T) {
 			Value: "receive",
 		}},
 	}}
-	require.Equal(t, expected_events, pres2.Events)
+	require.Equal(t, expected_events, prResponse2.Events)
 }
 
 func TestAnalyzeCode(t *testing.T) {

--- a/lib.go
+++ b/lib.go
@@ -127,7 +127,7 @@ func (vm *VM) Instantiate(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.Response, uint64, error) {
+) (*types.ContractResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -146,10 +146,7 @@ func (vm *VM) Instantiate(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if result.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", result.Err)
-	}
-	return result.Ok, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // Execute calls a given contract. Since the only difference between contracts with the same Checksum is the
@@ -169,7 +166,7 @@ func (vm *VM) Execute(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.Response, uint64, error) {
+) (*types.ContractResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -188,10 +185,7 @@ func (vm *VM) Execute(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if result.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", result.Err)
-	}
-	return result.Ok, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // Query allows a client to execute a contract-specific query. If the result is not empty, it should be
@@ -207,7 +201,7 @@ func (vm *VM) Query(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) ([]byte, uint64, error) {
+) (*types.QueryResponse, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -222,10 +216,7 @@ func (vm *VM) Query(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // Migrate will migrate an existing contract to a new code binary.
@@ -244,7 +235,7 @@ func (vm *VM) Migrate(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.Response, uint64, error) {
+) (*types.ContractResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -259,10 +250,7 @@ func (vm *VM) Migrate(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // Sudo allows native Go modules to make priviledged (sudo) calls on the contract.
@@ -281,7 +269,7 @@ func (vm *VM) Sudo(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.Response, uint64, error) {
+) (*types.ContractResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -296,10 +284,7 @@ func (vm *VM) Sudo(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // Reply allows the native Go wasm modules to make a priviledged call to return the result
@@ -316,7 +301,7 @@ func (vm *VM) Reply(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.Response, uint64, error) {
+) (*types.ContractResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -335,10 +320,7 @@ func (vm *VM) Reply(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // IBCChannelOpen is available on IBC-enabled contracts and is a hook to call into
@@ -353,7 +335,7 @@ func (vm *VM) IBCChannelOpen(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.IBC3ChannelOpenResponse, uint64, error) {
+) (*types.IBCChannelOpenResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -372,10 +354,7 @@ func (vm *VM) IBCChannelOpen(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // IBCChannelConnect is available on IBC-enabled contracts and is a hook to call into
@@ -390,7 +369,7 @@ func (vm *VM) IBCChannelConnect(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.IBCBasicResponse, uint64, error) {
+) (*types.IBCBasicResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -409,10 +388,7 @@ func (vm *VM) IBCChannelConnect(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // IBCChannelClose is available on IBC-enabled contracts and is a hook to call into
@@ -427,7 +403,7 @@ func (vm *VM) IBCChannelClose(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.IBCBasicResponse, uint64, error) {
+) (*types.IBCBasicResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -446,10 +422,7 @@ func (vm *VM) IBCChannelClose(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // IBCPacketReceive is available on IBC-enabled contracts and is called when an incoming
@@ -499,7 +472,7 @@ func (vm *VM) IBCPacketAck(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.IBCBasicResponse, uint64, error) {
+) (*types.IBCBasicResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -518,10 +491,7 @@ func (vm *VM) IBCPacketAck(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 // IBCPacketTimeout is available on IBC-enabled contracts and is called when an
@@ -537,7 +507,7 @@ func (vm *VM) IBCPacketTimeout(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.IBCBasicResponse, uint64, error) {
+) (*types.IBCBasicResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -556,10 +526,7 @@ func (vm *VM) IBCPacketTimeout(
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	if resp.Err != "" {
-		return nil, gasReport.UsedInternally, fmt.Errorf("%s", resp.Err)
-	}
-	return resp.Ok, gasReport.UsedInternally, nil
+	return &resp, gasReport.UsedInternally, nil
 }
 
 func DeserializeResponse(gasLimit uint64, deserCost types.UFraction, gasReport *types.GasReport, data []byte, response any) error {

--- a/lib.go
+++ b/lib.go
@@ -245,12 +245,12 @@ func (vm *VM) Migrate(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.ContractResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.ContractResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // Sudo allows native Go modules to make priviledged (sudo) calls on the contract.
@@ -279,12 +279,12 @@ func (vm *VM) Sudo(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.ContractResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.ContractResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // Reply allows the native Go wasm modules to make a priviledged call to return the result
@@ -315,12 +315,12 @@ func (vm *VM) Reply(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.ContractResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.ContractResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // IBCChannelOpen is available on IBC-enabled contracts and is a hook to call into
@@ -349,12 +349,12 @@ func (vm *VM) IBCChannelOpen(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.IBCChannelOpenResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.IBCChannelOpenResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // IBCChannelConnect is available on IBC-enabled contracts and is a hook to call into
@@ -383,12 +383,12 @@ func (vm *VM) IBCChannelConnect(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.IBCBasicResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.IBCBasicResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // IBCChannelClose is available on IBC-enabled contracts and is a hook to call into
@@ -417,12 +417,12 @@ func (vm *VM) IBCChannelClose(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.IBCBasicResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.IBCBasicResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // IBCPacketReceive is available on IBC-enabled contracts and is called when an incoming
@@ -451,12 +451,12 @@ func (vm *VM) IBCPacketReceive(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.IBCReceiveResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.IBCReceiveResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // IBCPacketAck is available on IBC-enabled contracts and is called when an
@@ -486,12 +486,12 @@ func (vm *VM) IBCPacketAck(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.IBCBasicResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.IBCBasicResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // IBCPacketTimeout is available on IBC-enabled contracts and is called when an
@@ -521,12 +521,12 @@ func (vm *VM) IBCPacketTimeout(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.IBCBasicResult
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.IBCBasicResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 func DeserializeResponse(gasLimit uint64, deserCost types.UFraction, gasReport *types.GasReport, data []byte, response any) error {

--- a/lib_test.go
+++ b/lib_test.go
@@ -146,8 +146,10 @@ func TestHappyPath(t *testing.T) {
 	env := api.MockEnv()
 	info := api.MockInfo("creator", nil)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
-	ires, _, err := vm.Instantiate(checksum, env, info, msg, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err := vm.Instantiate(checksum, env, info, msg, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires := i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// execute
@@ -155,8 +157,10 @@ func TestHappyPath(t *testing.T) {
 	store.SetGasMeter(gasMeter2)
 	env = api.MockEnv()
 	info = api.MockInfo("fred", nil)
-	hres, _, err := vm.Execute(checksum, env, info, []byte(`{"release":{}}`), store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
+	h, _, err := vm.Execute(checksum, env, info, []byte(`{"release":{}}`), store, *goapi, querier, gasMeter2, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, h.Ok)
+	hres := h.Ok
 	require.Equal(t, 1, len(hres.Messages))
 
 	// make sure it read the balance properly and we got 250 atoms
@@ -186,8 +190,10 @@ func TestEnv(t *testing.T) {
 	// instantiate
 	env := api.MockEnv()
 	info := api.MockInfo("creator", nil)
-	ires, _, err := vm.Instantiate(checksum, env, info, []byte(`{}`), store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err := vm.Instantiate(checksum, env, info, []byte(`{}`), store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires := i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// Execute mirror env without Transaction
@@ -204,8 +210,10 @@ func TestEnv(t *testing.T) {
 	}
 	info = api.MockInfo("creator", nil)
 	msg := []byte(`{"mirror_env": {}}`)
-	ires, _, err = vm.Execute(checksum, env, info, msg, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err = vm.Execute(checksum, env, info, msg, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires = i.Ok
 	expected, _ := json.Marshal(env)
 	require.Equal(t, expected, ires.Data)
 
@@ -225,8 +233,10 @@ func TestEnv(t *testing.T) {
 	}
 	info = api.MockInfo("creator", nil)
 	msg = []byte(`{"mirror_env": {}}`)
-	ires, _, err = vm.Execute(checksum, env, info, msg, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err = vm.Execute(checksum, env, info, msg, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires = i.Ok
 	expected, _ = json.Marshal(env)
 	require.Equal(t, expected, ires.Data)
 }
@@ -260,8 +270,10 @@ func TestGetMetrics(t *testing.T) {
 	env := api.MockEnv()
 	info := api.MockInfo("creator", nil)
 	msg1 := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
-	ires, _, err := vm.Instantiate(checksum, env, info, msg1, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err := vm.Instantiate(checksum, env, info, msg1, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires := i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// GetMetrics 3
@@ -274,8 +286,10 @@ func TestGetMetrics(t *testing.T) {
 
 	// Instantiate 2
 	msg2 := []byte(`{"verifier": "fred", "beneficiary": "susi"}`)
-	ires, _, err = vm.Instantiate(checksum, env, info, msg2, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err = vm.Instantiate(checksum, env, info, msg2, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires = i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// GetMetrics 4
@@ -302,8 +316,10 @@ func TestGetMetrics(t *testing.T) {
 
 	// Instantiate 3
 	msg3 := []byte(`{"verifier": "fred", "beneficiary": "bert"}`)
-	ires, _, err = vm.Instantiate(checksum, env, info, msg3, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err = vm.Instantiate(checksum, env, info, msg3, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires = i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// GetMetrics 6
@@ -334,8 +350,10 @@ func TestGetMetrics(t *testing.T) {
 
 	// Instantiate 4
 	msg4 := []byte(`{"verifier": "fred", "beneficiary": "jeff"}`)
-	ires, _, err = vm.Instantiate(checksum, env, info, msg4, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
+	i, _, err = vm.Instantiate(checksum, env, info, msg4, store, *goapi, querier, gasMeter1, TESTING_GAS_LIMIT, deserCost)
 	require.NoError(t, err)
+	require.NotNil(t, i.Ok)
+	ires = i.Ok
 	require.Equal(t, 0, len(ires.Messages))
 
 	// GetMetrics 8


### PR DESCRIPTION
closes #398

This should also allow wasmd to handle contract errors and vm errors differently