### PR TITLE
Handle both `stargate` and `any` CosmosMsg variant

### DIFF
--- a/types/msg.go
+++ b/types/msg.go
@@ -126,8 +126,10 @@ func (m *CosmosMsg) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Use "Any" for both variants
-	if tmp.Any == nil && tmp.Stargate != nil {
+	if tmp.Any != nil && tmp.Stargate != nil {
+		return fmt.Errorf("invalid CosmosMsg: both 'any' and 'stargate' fields are set")
+	} else if tmp.Any == nil && tmp.Stargate != nil {
+		// Use "Any" for both variants
 		tmp.Any = tmp.Stargate
 	}
 

--- a/types/msg.go
+++ b/types/msg.go
@@ -103,7 +103,7 @@ type CosmosMsg struct {
 	Gov          *GovMsg          `json:"gov,omitempty"`
 	IBC          *IBCMsg          `json:"ibc,omitempty"`
 	Staking      *StakingMsg      `json:"staking,omitempty"`
-	Stargate     *StargateMsg     `json:"any,omitempty"`
+	Any          *AnyMsg          `json:"any,omitempty"`
 	Wasm         *WasmMsg         `json:"wasm,omitempty"`
 }
 
@@ -116,9 +116,9 @@ func (m *CosmosMsg) UnmarshalJSON(data []byte) error {
 		Gov          *GovMsg          `json:"gov,omitempty"`
 		IBC          *IBCMsg          `json:"ibc,omitempty"`
 		Staking      *StakingMsg      `json:"staking,omitempty"`
-		Any          *StargateMsg     `json:"any,omitempty"`
+		Any          *AnyMsg          `json:"any,omitempty"`
 		Wasm         *WasmMsg         `json:"wasm,omitempty"`
-		Stargate     *StargateMsg     `json:"stargate,omitempty"`
+		Stargate     *AnyMsg          `json:"stargate,omitempty"`
 	}
 	var tmp InternalCosmosMsg
 	err := json.Unmarshal(data, &tmp)
@@ -126,9 +126,9 @@ func (m *CosmosMsg) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Use "Stargate" for both variants
-	if tmp.Stargate == nil && tmp.Any != nil {
-		tmp.Stargate = tmp.Any
+	// Use "Any" for both variants
+	if tmp.Any == nil && tmp.Stargate != nil {
+		tmp.Any = tmp.Stargate
 	}
 
 	*m = CosmosMsg{
@@ -138,7 +138,7 @@ func (m *CosmosMsg) UnmarshalJSON(data []byte) error {
 		Gov:          tmp.Gov,
 		IBC:          tmp.IBC,
 		Staking:      tmp.Staking,
-		Stargate:     tmp.Stargate,
+		Any:          tmp.Any,
 		Wasm:         tmp.Wasm,
 	}
 	return nil
@@ -309,9 +309,9 @@ type FundCommunityPoolMsg struct {
 	Amount Coins `json:"amount"`
 }
 
-// StargateMsg is encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+// AnyMsg is encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
 // This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
-type StargateMsg struct {
+type AnyMsg struct {
 	TypeURL string `json:"type_url"`
 	Value   []byte `json:"value"`
 }

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -104,6 +104,15 @@ func TestAnyMsgSerialization(t *testing.T) {
 	serialized, err := json.Marshal(res)
 	require.NoError(t, err)
 	require.Equal(t, document2, serialized)
+
+	// test providing both variants is rejected
+	document3 := []byte(`{
+		"stargate":{"type_url":"/cosmos.foo.v1beta.MsgBar","value":"5yu/rQ+HrMcxH1zdga7P5hpGMLE="},
+		"any":{"type_url":"/cosmos.foo.v1beta.MsgBar","value":"5yu/rQ+HrMcxH1zdga7P5hpGMLE="}
+	}`)
+	var res3 CosmosMsg
+	err = json.Unmarshal(document3, &res3)
+	require.Error(t, err)
 }
 
 func TestGovMsgVoteSerialization(t *testing.T) {

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -74,6 +75,35 @@ func TestWasmMsgInstantiate2Serialization(t *testing.T) {
 	}, msg.Instantiate2.Funds)
 	require.Equal(t, "my instance", msg.Instantiate2.Label)
 	require.Equal(t, []byte{0x52, 0x43, 0x95, 0x6b, 0x38, 0x62, 0xc2, 0x8a}, msg.Instantiate2.Salt)
+}
+
+func TestAnyMsgSerialization(t *testing.T) {
+	expectedData, err := base64.StdEncoding.DecodeString("5yu/rQ+HrMcxH1zdga7P5hpGMLE=")
+	require.NoError(t, err)
+
+	// test backwards compatibility with old stargate variant
+	document1 := []byte(`{"stargate":{"type_url":"/cosmos.foo.v1beta.MsgBar","value":"5yu/rQ+HrMcxH1zdga7P5hpGMLE="}}`)
+	var res CosmosMsg
+	err = json.Unmarshal(document1, &res)
+	require.NoError(t, err)
+	require.Equal(t, CosmosMsg{
+		Stargate: &StargateMsg{
+			TypeURL: "/cosmos.foo.v1beta.MsgBar",
+			Value:   expectedData,
+		},
+	}, res)
+
+	// test new any variant
+	document2 := []byte(`{"any":{"type_url":"/cosmos.foo.v1beta.MsgBar","value":"5yu/rQ+HrMcxH1zdga7P5hpGMLE="}}`)
+	var res2 CosmosMsg
+	err = json.Unmarshal(document2, &res2)
+	require.NoError(t, err)
+	require.Equal(t, res, res2)
+
+	// serializing should use the new any variant
+	serialized, err := json.Marshal(res)
+	require.NoError(t, err)
+	require.Equal(t, document2, serialized)
 }
 
 func TestGovMsgVoteSerialization(t *testing.T) {

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -87,7 +87,7 @@ func TestAnyMsgSerialization(t *testing.T) {
 	err = json.Unmarshal(document1, &res)
 	require.NoError(t, err)
 	require.Equal(t, CosmosMsg{
-		Stargate: &StargateMsg{
+		Any: &AnyMsg{
 			TypeURL: "/cosmos.foo.v1beta.MsgBar",
 			Value:   expectedData,
 		},


### PR DESCRIPTION
Companion to CosmWasm/cosmwasm#1926

Unfortunately I did not find a succinct way to do this in Go.
The other option would be to keep both variants in the struct, make them private and add a `Stargate` / `Any` function that differentiates them. But that would also need changes in wasmd.