### PR TITLE
Add zero timestamp to TestIbcTimeoutDeserialization

### DIFF
--- a/types/ibc_test.go
+++ b/types/ibc_test.go
@@ -80,4 +80,15 @@ func TestIbcTimeoutDeserialization(t *testing.T) {
 		},
 		Timestamp: 0,
 	}, timeout3)
+
+	// Zero timestamp
+	// This is not very useful but something a contract developer can do in the current type
+	// system by setting timestamp to IbcTimeout::with_timestamp(Timestamp::from_nanos(0))
+	var timeout4 IBCTimeout
+	err = json.Unmarshal([]byte(`{"block":null,"timestamp":"0"}`), &timeout4)
+	require.NoError(t, err)
+	assert.Equal(t, IBCTimeout{
+		Block:     nil,
+		Timestamp: 0,
+	}, timeout4)
 }


### PR DESCRIPTION
Just one more test to cover a possible deserialization scenario.