### PR TITLE
Rename `QueryResponse` to `QueryResult`

### DIFF
--- a/internal/api/iterator_test.go
+++ b/internal/api/iterator_test.go
@@ -182,17 +182,17 @@ func TestQueueIteratorSimple(t *testing.T) {
 	env := MockEnvBin(t)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
+	var qResult types.QueryResult
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
-	require.Equal(t, `{"sum":39}`, string(qres.Ok))
+	require.Equal(t, "", qResult.Err)
+	require.Equal(t, `{"sum":39}`, string(qResult.Ok))
 
 	// query reduce (multiple iterators at once)
 	query = []byte(`{"reducer":{}}`)
 	data, _, err = Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var reduced types.QueryResponse
+	var reduced types.QueryResult
 	err = json.Unmarshal(data, &reduced)
 	require.NoError(t, err)
 	require.Equal(t, "", reduced.Err)
@@ -220,7 +220,7 @@ func TestQueueIteratorRaces(t *testing.T) {
 		query := []byte(`{"reducer":{}}`)
 		data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 		require.NoError(t, err)
-		var reduced types.QueryResponse
+		var reduced types.QueryResult
 		err = json.Unmarshal(data, &reduced)
 		require.NoError(t, err)
 		require.Equal(t, "", reduced.Err)
@@ -261,7 +261,7 @@ func TestQueueIteratorLimit(t *testing.T) {
 	checksum, querier, api := setup.checksum, setup.querier, setup.api
 
 	var err error
-	var qres types.QueryResponse
+	var qResult types.QueryResult
 	var gasLimit uint64
 
 	// Open 5000 iterators
@@ -273,10 +273,10 @@ func TestQueueIteratorLimit(t *testing.T) {
 	env := MockEnvBin(t)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, gasLimit, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	err = json.Unmarshal(data, &qres)
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
-	require.Equal(t, `{}`, string(qres.Ok))
+	require.Equal(t, "", qResult.Err)
+	require.Equal(t, `{}`, string(qResult.Ok))
 
 	// Open 35000 iterators
 	gasLimit = TESTING_GAS_LIMIT * 4

--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -961,10 +961,10 @@ func TestQuery(t *testing.T) {
 	query := []byte(`{"Raw":{"val":"config"}}`)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter2, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var badResp types.QueryResult
-	err = json.Unmarshal(data, &badResp)
+	var badResult types.QueryResult
+	err = json.Unmarshal(data, &badResult)
 	require.NoError(t, err)
-	require.Contains(t, badResp.Err, "Error parsing into type hackatom::msg::QueryMsg: unknown variant `Raw`, expected one of")
+	require.Contains(t, badResult.Err, "Error parsing into type hackatom::msg::QueryMsg: unknown variant `Raw`, expected one of")
 
 	// make a valid query
 	gasMeter3 := NewMockGasMeter(TESTING_GAS_LIMIT)

--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -627,11 +627,11 @@ func TestMigrate(t *testing.T) {
 	query := []byte(`{"verifier":{}}`)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
+	var qResult types.QueryResult
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
-	require.Equal(t, string(qres.Ok), `{"verifier":"fred"}`)
+	require.Equal(t, "", qResult.Err)
+	require.Equal(t, string(qResult.Ok), `{"verifier":"fred"}`)
 
 	// migrate to a new verifier - alice
 	// we use the same code blob as we are testing hackatom self-migration
@@ -641,11 +641,11 @@ func TestMigrate(t *testing.T) {
 	// should update verifier to alice
 	data, _, err = Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres2 types.QueryResponse
-	err = json.Unmarshal(data, &qres2)
+	var qResult2 types.QueryResult
+	err = json.Unmarshal(data, &qResult2)
 	require.NoError(t, err)
-	require.Equal(t, "", qres2.Err)
-	require.Equal(t, `{"verifier":"alice"}`, string(qres2.Ok))
+	require.Equal(t, "", qResult2.Err)
+	require.Equal(t, `{"verifier":"alice"}`, string(qResult2.Ok))
 }
 
 func TestMultipleInstances(t *testing.T) {
@@ -856,10 +856,10 @@ func TestReplyAndQuery(t *testing.T) {
 	query := []byte(`{"sub_msg_result":{"id":1234}}`)
 	res, _, err = Query(cache, checksum, env, query, &igasMeter2, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	qres := requireQueryOk(t, res)
+	qResult := requireQueryOk(t, res)
 
 	var stored types.Reply
-	err = json.Unmarshal(qres, &stored)
+	err = json.Unmarshal(qResult, &stored)
 	require.NoError(t, err)
 	assert.Equal(t, id, stored.ID)
 	require.NotNil(t, stored.Result.Ok)
@@ -877,7 +877,7 @@ func requireOkResponse(t *testing.T, res []byte, expectedMsgs int) {
 }
 
 func requireQueryError(t *testing.T, res []byte) {
-	var result types.QueryResponse
+	var result types.QueryResult
 	err := json.Unmarshal(res, &result)
 	require.NoError(t, err)
 	require.Empty(t, result.Ok)
@@ -885,7 +885,7 @@ func requireQueryError(t *testing.T, res []byte) {
 }
 
 func requireQueryOk(t *testing.T, res []byte) []byte {
-	var result types.QueryResponse
+	var result types.QueryResult
 	err := json.Unmarshal(res, &result)
 	require.NoError(t, err)
 	require.Empty(t, result.Err)
@@ -961,7 +961,7 @@ func TestQuery(t *testing.T) {
 	query := []byte(`{"Raw":{"val":"config"}}`)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter2, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var badResp types.QueryResponse
+	var badResp types.QueryResult
 	err = json.Unmarshal(data, &badResp)
 	require.NoError(t, err)
 	require.Contains(t, badResp.Err, "Error parsing into type hackatom::msg::QueryMsg: unknown variant `Raw`, expected one of")
@@ -973,11 +973,11 @@ func TestQuery(t *testing.T) {
 	query = []byte(`{"verifier":{}}`)
 	data, _, err = Query(cache, checksum, env, query, &igasMeter3, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
+	var qResult types.QueryResult
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
-	require.Equal(t, string(qres.Ok), `{"verifier":"fred"}`)
+	require.Equal(t, "", qResult.Err)
+	require.Equal(t, string(qResult.Ok), `{"verifier":"fred"}`)
 }
 
 func TestHackatomQuerier(t *testing.T) {
@@ -999,12 +999,12 @@ func TestHackatomQuerier(t *testing.T) {
 	env := MockEnvBin(t)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
+	var qResult types.QueryResult
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
+	require.Equal(t, "", qResult.Err)
 	var balances types.AllBalancesResponse
-	err = json.Unmarshal(qres.Ok, &balances)
+	err = json.Unmarshal(qResult.Ok, &balances)
 	require.NoError(t, err)
 	require.Equal(t, balances.Amount, initBalance)
 }
@@ -1051,13 +1051,13 @@ func TestCustomReflectQuerier(t *testing.T) {
 	env := MockEnvBin(t)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
+	var qResult types.QueryResult
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
+	require.Equal(t, "", qResult.Err)
 
 	var response CapitalizedResponse
-	err = json.Unmarshal(qres.Ok, &response)
+	err = json.Unmarshal(qResult.Ok, &response)
 	require.NoError(t, err)
 	require.Equal(t, "SMALL FRYS :)", response.Text)
 }
@@ -1103,12 +1103,12 @@ func TestFloats(t *testing.T) {
 	query := []byte(`{"instructions":{}}`)
 	data, _, err := Query(cache, checksum, env, query, &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
+	var qResult types.QueryResult
+	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qres.Err)
+	require.Equal(t, "", qResult.Err)
 	var instructions []string
-	err = json.Unmarshal(qres.Ok, &instructions)
+	err = json.Unmarshal(qResult.Ok, &instructions)
 	require.NoError(t, err)
 	// little sanity check
 	require.Equal(t, 70, len(instructions))
@@ -1121,11 +1121,11 @@ func TestFloats(t *testing.T) {
 			msg := fmt.Sprintf(`{"random_args_for":{"instruction":"%s","seed":%d}}`, instr, seed)
 			data, _, err = Query(cache, checksum, env, []byte(msg), &igasMeter, store, api, &querier, TESTING_GAS_LIMIT, TESTING_PRINT_DEBUG)
 			require.NoError(t, err)
-			err = json.Unmarshal(data, &qres)
+			err = json.Unmarshal(data, &qResult)
 			require.NoError(t, err)
-			require.Equal(t, "", qres.Err)
+			require.Equal(t, "", qResult.Err)
 			var args []Value
-			err = json.Unmarshal(qres.Ok, &args)
+			err = json.Unmarshal(qResult.Ok, &args)
 			require.NoError(t, err)
 
 			// build the run message
@@ -1142,11 +1142,11 @@ func TestFloats(t *testing.T) {
 				// remove the prefix to make the error message the same as in the cosmwasm-vm test
 				result = strings.Replace(err.Error(), "Error calling the VM: Error executing Wasm: ", "", 1)
 			} else {
-				err = json.Unmarshal(data, &qres)
+				err = json.Unmarshal(data, &qResult)
 				require.NoError(t, err)
-				require.Equal(t, "", qres.Err)
+				require.Equal(t, "", qResult.Err)
 				var response Value
-				err = json.Unmarshal(qres.Ok, &response)
+				err = json.Unmarshal(qResult.Ok, &response)
 				require.NoError(t, err)
 				result = debugStr(response)
 			}

--- a/lib.go
+++ b/lib.go
@@ -201,7 +201,7 @@ func (vm *VM) Query(
 	gasMeter GasMeter,
 	gasLimit uint64,
 	deserCost types.UFraction,
-) (*types.QueryResponse, uint64, error) {
+) (*types.QueryResult, uint64, error) {
 	envBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -211,12 +211,12 @@ func (vm *VM) Query(
 		return nil, gasReport.UsedInternally, err
 	}
 
-	var resp types.QueryResponse
-	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &resp)
+	var result types.QueryResult
+	err = DeserializeResponse(gasLimit, deserCost, &gasReport, data, &result)
 	if err != nil {
 		return nil, gasReport.UsedInternally, err
 	}
-	return &resp, gasReport.UsedInternally, nil
+	return &result, gasReport.UsedInternally, nil
 }
 
 // Migrate will migrate an existing contract to a new code binary.

--- a/types/queries.go
+++ b/types/queries.go
@@ -6,24 +6,24 @@ import (
 
 //-------- Queries --------
 
-// QueryResponse is the Go counterpart of `ContractResult<Binary>`.
+// QueryResult is the Go counterpart of `ContractResult<Binary>`.
 // The JSON annotations are used for deserializing directly. There is a custom serializer below.
-type QueryResponse queryResponseImpl
+type QueryResult queryResultImpl
 
-type queryResponseImpl struct {
+type queryResultImpl struct {
 	Ok  []byte `json:"ok,omitempty"`
 	Err string `json:"error,omitempty"`
 }
 
-// A custom serializer that allows us to map QueryResponse instances to the Rust
+// A custom serializer that allows us to map QueryResult instances to the Rust
 // enum `ContractResult<Binary>`
-func (q QueryResponse) MarshalJSON() ([]byte, error) {
+func (q QueryResult) MarshalJSON() ([]byte, error) {
 	// In case both Ok and Err are empty, this is interpreted and seralized
 	// as an Ok case with no data because errors must not be empty.
 	if len(q.Ok) == 0 && len(q.Err) == 0 {
 		return []byte(`{"ok":""}`), nil
 	}
-	return json.Marshal(queryResponseImpl(q))
+	return json.Marshal(queryResultImpl(q))
 }
 
 //-------- Querier -----------
@@ -72,14 +72,14 @@ func RustQuery(querier Querier, binRequest []byte, gasLimit uint64) QuerierResul
 
 // This is a 2-level result
 type QuerierResult struct {
-	Ok  *QueryResponse `json:"ok,omitempty"`
-	Err *SystemError   `json:"error,omitempty"`
+	Ok  *QueryResult `json:"ok,omitempty"`
+	Err *SystemError `json:"error,omitempty"`
 }
 
 func ToQuerierResult(response []byte, err error) QuerierResult {
 	if err == nil {
 		return QuerierResult{
-			Ok: &QueryResponse{
+			Ok: &QueryResult{
 				Ok: response,
 			},
 		}
@@ -91,7 +91,7 @@ func ToQuerierResult(response []byte, err error) QuerierResult {
 		}
 	}
 	return QuerierResult{
-		Ok: &QueryResponse{
+		Ok: &QueryResult{
 			Err: err.Error(),
 		},
 	}

--- a/types/queries_test.go
+++ b/types/queries_test.go
@@ -63,30 +63,30 @@ func TestValidatorWithData(t *testing.T) {
 	assert.Equal(t, reval, val)
 }
 
-func TestQueryResponseWithEmptyData(t *testing.T) {
+func TestQueryResultWithEmptyData(t *testing.T) {
 	cases := map[string]struct {
-		req       QueryResponse
+		req       QueryResult
 		resp      string
 		unmarshal bool
 	}{
 		"ok with data": {
-			req: QueryResponse{Ok: []byte("foo")},
+			req: QueryResult{Ok: []byte("foo")},
 			// base64-encoded "foo"
 			resp:      `{"ok":"Zm9v"}`,
 			unmarshal: true,
 		},
 		"error": {
-			req:       QueryResponse{Err: "try again later"},
+			req:       QueryResult{Err: "try again later"},
 			resp:      `{"error":"try again later"}`,
 			unmarshal: true,
 		},
 		"ok with empty slice": {
-			req:       QueryResponse{Ok: []byte{}},
+			req:       QueryResult{Ok: []byte{}},
 			resp:      `{"ok":""}`,
 			unmarshal: true,
 		},
 		"nil data": {
-			req:  QueryResponse{},
+			req:  QueryResult{},
 			resp: `{"ok":""}`,
 			// Once converted to the Rust enum `ContractResult<Binary>` or
 			// its JSON serialization, we cannot differentiate between
@@ -105,7 +105,7 @@ func TestQueryResponseWithEmptyData(t *testing.T) {
 
 			// if unmarshall, make sure this comes back to the proper state
 			if tc.unmarshal {
-				var parsed QueryResponse
+				var parsed QueryResult
 				err = json.Unmarshal(data, &parsed)
 				require.NoError(t, err)
 				require.Equal(t, tc.req, parsed)


### PR DESCRIPTION
closes #475