### PR TITLE
Improve Go linting

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -1,8 +1,9 @@
 name: golangci-lint
+
+# Long living branches and all PRs
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 
@@ -19,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21.4'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
@@ -27,7 +28,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.53
+          version: v1.55.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	wasmvm "github.com/CosmWasm/wasmvm"
@@ -29,7 +28,7 @@ func main() {
 	}
 
 	fmt.Printf("Running %s...\n", file)
-	bz, err := ioutil.ReadFile(file)
+	bz, err := os.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -4,7 +4,7 @@ package cosmwasm
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +19,7 @@ const IBC_TEST_CONTRACT = "./testdata/ibc_reflect.wasm"
 func TestIBC(t *testing.T) {
 	vm := withVM(t)
 
-	wasm, err := ioutil.ReadFile(IBC_TEST_CONTRACT)
+	wasm, err := os.ReadFile(IBC_TEST_CONTRACT)
 	require.NoError(t, err)
 
 	checksum, err := vm.StoreCode(wasm)
@@ -293,7 +293,7 @@ func TestAnalyzeCode(t *testing.T) {
 	vm := withVM(t)
 
 	// Store non-IBC contract
-	wasm, err := ioutil.ReadFile(HACKATOM_TEST_CONTRACT)
+	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 	checksum, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestAnalyzeCode(t *testing.T) {
 	require.Equal(t, "", report.RequiredCapabilities)
 
 	// Store IBC contract
-	wasm2, err := ioutil.ReadFile(IBC_TEST_CONTRACT)
+	wasm2, err := os.ReadFile(IBC_TEST_CONTRACT)
 	require.NoError(t, err)
 	checksum2, err := vm.StoreCode(wasm2)
 	require.NoError(t, err)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +15,7 @@ func TestValidateAddressFailure(t *testing.T) {
 	defer cleanup()
 
 	// create contract
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 	checksum, err := StoreCode(cache, wasm)
 	require.NoError(t, err)

--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ const (
 )
 
 func TestInitAndReleaseCache(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "wasmvm-testing")
+	tmpdir, err := os.MkdirTemp("", "wasmvm-testing")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -39,7 +38,7 @@ func TestInitAndReleaseCache(t *testing.T) {
 // wasmd expects us to create the base directory
 // https://github.com/CosmWasm/wasmd/blob/v0.30.0/x/wasm/keeper/keeper.go#L128
 func TestInitCacheWorksForNonExistentDir(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "wasmvm-testing")
+	tmpdir, err := os.MkdirTemp("", "wasmvm-testing")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -59,7 +58,7 @@ func TestInitCacheErrorsForBrokenDir(t *testing.T) {
 }
 
 func TestInitCacheEmptyCapabilities(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "wasmvm-testing")
+	tmpdir, err := os.MkdirTemp("", "wasmvm-testing")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	cache, err := InitCache(tmpdir, "", TESTING_CACHE_SIZE, TESTING_MEMORY_LIMIT)
@@ -68,7 +67,7 @@ func TestInitCacheEmptyCapabilities(t *testing.T) {
 }
 
 func withCache(t *testing.T) (Cache, func()) {
-	tmpdir, err := ioutil.TempDir("", "wasmvm-testing")
+	tmpdir, err := os.MkdirTemp("", "wasmvm-testing")
 	require.NoError(t, err)
 	cache, err := InitCache(tmpdir, TESTING_CAPABILITIES, TESTING_CACHE_SIZE, TESTING_MEMORY_LIMIT)
 	require.NoError(t, err)
@@ -84,7 +83,7 @@ func TestStoreCodeAndGetCode(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	checksum, err := StoreCode(cache, wasm)
@@ -101,7 +100,7 @@ func TestRemoveCode(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	checksum, err := StoreCode(cache, wasm)
@@ -129,7 +128,7 @@ func TestStoreCodeUnchecked(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	checksum, err := StoreCodeUnchecked(cache, wasm)
@@ -146,7 +145,7 @@ func TestPin(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	checksum, err := StoreCode(cache, wasm)
@@ -189,7 +188,7 @@ func TestUnpin(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	checksum, err := StoreCode(cache, wasm)
@@ -234,7 +233,7 @@ func TestGetMetrics(t *testing.T) {
 	assert.Equal(t, &types.Metrics{}, metrics)
 
 	// Store contract
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 	checksum, err := StoreCode(cache, wasm)
 	require.NoError(t, err)
@@ -345,7 +344,7 @@ func TestInstantiate(t *testing.T) {
 	defer cleanup()
 
 	// create contract
-	wasm, err := ioutil.ReadFile("../../testdata/hackatom.wasm")
+	wasm, err := os.ReadFile("../../testdata/hackatom.wasm")
 	require.NoError(t, err)
 	checksum, err := StoreCode(cache, wasm)
 	require.NoError(t, err)
@@ -914,7 +913,7 @@ func createFloaty2(t *testing.T, cache Cache) []byte {
 }
 
 func createContract(t *testing.T, cache Cache, wasmFile string) []byte {
-	wasm, err := ioutil.ReadFile(wasmFile)
+	wasm, err := os.ReadFile(wasmFile)
 	require.NoError(t, err)
 	checksum, err := StoreCode(cache, wasm)
 	require.NoError(t, err)

--- a/lib_test.go
+++ b/lib_test.go
@@ -4,7 +4,6 @@ package cosmwasm
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,7 +28,7 @@ const (
 )
 
 func withVM(t *testing.T) *VM {
-	tmpdir, err := ioutil.TempDir("", "wasmvm-testing")
+	tmpdir, err := os.MkdirTemp("", "wasmvm-testing")
 	require.NoError(t, err)
 	vm, err := NewVM(tmpdir, TESTING_CAPABILITIES, TESTING_MEMORY_LIMIT, TESTING_PRINT_DEBUG, TESTING_CACHE_SIZE)
 	require.NoError(t, err)
@@ -42,7 +41,7 @@ func withVM(t *testing.T) *VM {
 }
 
 func createTestContract(t *testing.T, vm *VM, path string) Checksum {
-	wasm, err := ioutil.ReadFile(path)
+	wasm, err := os.ReadFile(path)
 	require.NoError(t, err)
 	checksum, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
@@ -54,7 +53,7 @@ func TestStoreCode(t *testing.T) {
 
 	// Valid hackatom contract
 	{
-		wasm, err := ioutil.ReadFile(HACKATOM_TEST_CONTRACT)
+		wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 		require.NoError(t, err)
 		_, err = vm.StoreCode(wasm)
 		require.NoError(t, err)
@@ -62,7 +61,7 @@ func TestStoreCode(t *testing.T) {
 
 	// Valid cyberpunk contract
 	{
-		wasm, err := ioutil.ReadFile(CYBERPUNK_TEST_CONTRACT)
+		wasm, err := os.ReadFile(CYBERPUNK_TEST_CONTRACT)
 		require.NoError(t, err)
 		_, err = vm.StoreCode(wasm)
 		require.NoError(t, err)
@@ -103,7 +102,7 @@ func TestStoreCode(t *testing.T) {
 func TestStoreCodeAndGet(t *testing.T) {
 	vm := withVM(t)
 
-	wasm, err := ioutil.ReadFile(HACKATOM_TEST_CONTRACT)
+	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 
 	checksum, err := vm.StoreCode(wasm)
@@ -117,7 +116,7 @@ func TestStoreCodeAndGet(t *testing.T) {
 func TestRemoveCode(t *testing.T) {
 	vm := withVM(t)
 
-	wasm, err := ioutil.ReadFile(HACKATOM_TEST_CONTRACT)
+	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 
 	checksum, err := vm.StoreCode(wasm)


### PR DESCRIPTION
Prepares for a Go 1.21 upgrade. Pulled out of #478 but it's unrelated to the work there.