### PR TITLE
Remove Go dev environment from Alpine builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,8 @@ workflows:
               only:
                 # long living branches
                 - main
-                - 0.14-dev
+                # Development
+                - no-go-in-builder
       # Run only on main, not on tags (auto-build on merge PR)
       - deploy_to_git:
           requires:

--- a/Dockerfile.alpine_tester
+++ b/Dockerfile.alpine_tester
@@ -1,0 +1,7 @@
+FROM golang:1.21.4-alpine
+
+RUN apk add build-base
+
+# prepare go cache dirs
+RUN mkdir -p /.cache/go-build
+RUN chmod -R 777 /.cache

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ create-tester-image:
 	docker build -t $(ALPINE_TESTER) - < ./Dockerfile.alpine_tester
 
 test-alpine: release-build-alpine create-tester-image
+	@[ "$(shell uname -m)" = "x86_64" ] || (echo "This test is only working on x86_64. See https://github.com/CosmWasm/wasmvm/issues/483."; exit 78)
 # try running go tests using this lib with muslc
 	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd):/mnt/testrun -w /mnt/testrun $(ALPINE_TESTER) go build -tags muslc ./...
 # Use package list mode to include all subdirectores. The -count=1 turns off caching.

--- a/builders/Dockerfile.alpine
+++ b/builders/Dockerfile.alpine
@@ -1,26 +1,6 @@
-# This image is used for two things (which is not ideal, but yeah):
-# 1. Build the static Rust library
-# 2. Execute Go tests that use and test this library
-# For 2. we define the Go image here. For 1. we install Rust below.
-#
-# See also docs/COMPILER_VERSIONS.md
-FROM golang:1.20.10-alpine
+FROM rust:1.73.0-alpine
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-  CARGO_HOME=/usr/local/cargo \
-  PATH=/usr/local/cargo/bin:$PATH
-
-# this comes from standard alpine nightly file
-#  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
-# with some changes to support our toolchain, etc
-RUN set -eux \
-  && apk add --no-cache ca-certificates build-base
-
-RUN wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init" \
-  && chmod +x rustup-init \
-  && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.73.0 \
-  && rm rustup-init \
-  && chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+RUN apk add --no-cache ca-certificates build-base
 
 # Install C compiler for cross-compilation. This is required by
 # Wasmer in https://github.com/wasmerio/wasmer/blob/2.2.1/lib/vm/build.rs.
@@ -33,10 +13,6 @@ RUN wget https://musl.cc/aarch64-linux-musl-cross.tgz \
   && mv ./aarch64-linux-musl-cross /opt \
   && /opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc --version \
   && rm aarch64-linux-musl-cross.tgz
-
-# prepare go cache dirs
-RUN mkdir -p /.cache/go-build
-RUN chmod -R 777 /.cache
 
 # allow non-root user to download more deps later
 RUN chmod -R 777 /usr/local/cargo

--- a/builders/README.md
+++ b/builders/README.md
@@ -19,6 +19,10 @@ versions of the builder images.
 
 ## Changelog
 
+**Unreleased**
+
+- Remove Go dev environment from `cosmwasm/go-ext-builder:XXXX-alpine`
+
 **Version 0017:**
 
 - Update Rust to 1.73.0.


### PR DESCRIPTION
Pulled out of #478. Glad this is finally separated.