### PR TITLE
Let upcoming alpine builder use an x86_64 specific file name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,7 @@ jobs:
                   mkdir artifacts
 
                   # Static (from build)
+                  # TODO: Change this line to libwasmvm_muslc.x86_64.a when upgrading to builders 0018+
                   cp ./internal/api/libwasmvm_muslc.a artifacts/libwasmvm_muslc.x86_64.a
                   cp ./internal/api/libwasmvm_muslc.aarch64.a artifacts/libwasmvm_muslc.aarch64.a
                   cp ./internal/api/libwasmvmstatic_darwin.a artifacts/

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ release-build-alpine:
 	rm -rf libwasmvm/target/x86_64-unknown-linux-musl/release
 	# build the muslc *.a file
 	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd)/libwasmvm:/code $(BUILDERS_PREFIX)-alpine
+# TODO: Change this line to libwasmvm_muslc.x86_64.a when upgrading to builders 0018+
 	cp libwasmvm/artifacts/libwasmvm_muslc.a internal/api
 	cp libwasmvm/artifacts/libwasmvm_muslc.aarch64.a internal/api
 	make update-bindings

--- a/builders/README.md
+++ b/builders/README.md
@@ -22,6 +22,8 @@ versions of the builder images.
 **Unreleased**
 
 - Remove Go dev environment from `cosmwasm/go-ext-builder:XXXX-alpine`
+- Write x86_64 muslc output in `libwasmvm_muslc.x86_64.a` instead of
+  `libwasmvm_muslc.a`
 
 **Version 0017:**
 

--- a/builders/guest/build_muslc.sh
+++ b/builders/guest/build_muslc.sh
@@ -15,4 +15,4 @@ echo "Starting x86_64-unknown-linux-musl build"
 cargo build --release --target x86_64-unknown-linux-musl --example wasmvmstatic
 
 cp target/aarch64-unknown-linux-musl/release/examples/libwasmvmstatic.a artifacts/libwasmvm_muslc.aarch64.a
-cp target/x86_64-unknown-linux-musl/release/examples/libwasmvmstatic.a artifacts/libwasmvm_muslc.a
+cp target/x86_64-unknown-linux-musl/release/examples/libwasmvmstatic.a artifacts/libwasmvm_muslc.x86_64.a

--- a/internal/api/link_muslc.go
+++ b/internal/api/link_muslc.go
@@ -2,5 +2,7 @@
 
 package api
 
+// TODO: once we switch to builders 0018+, split this linking statement in x86_64 and arm64 like we do with the glibc case
+
 // #cgo LDFLAGS: -Wl,-rpath,${SRCDIR} -L${SRCDIR} -lwasmvm_muslc
 import "C"


### PR DESCRIPTION
First step for https://github.com/CosmWasm/wasmvm/issues/483