### PR TITLE
Add directory locking mechanism

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -17,6 +17,10 @@
 - CosmWasm gas values were reduced by a factor of 1000, so each instruction now
   consumes 150 CosmWasm gas instead of 150000. This should be taken into account
   when converting between CosmWasm gas and Cosmos SDK gas.
+- A new lockfile called `exclusive.lock` in the base directory ensures that no
+  two `VM` instances operate on the same directory in parallel. This was
+  unsupported before already but now leads to an error early on. When doing
+  parallel testing, use a different directory for each instance.
 
 ## Renamings
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/google/btree v1.0.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/sys v0.16.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/api/lib.go
+++ b/internal/api/lib.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/CosmWasm/wasmvm/types"
 )
 
@@ -55,7 +57,7 @@ func InitCache(dataDir string, supportedCapabilities []string, cacheSize uint32,
 		return Cache{}, fmt.Errorf("Error writing to exclusive.lock")
 	}
 
-	err = syscall.Flock(int(lockfile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	err = unix.Flock(int(lockfile.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 	if err != nil {
 		return Cache{}, fmt.Errorf("Could not lock exclusive.lock. Is a different VM running in the same directory already?")
 	}
@@ -81,7 +83,7 @@ func ReleaseCache(cache Cache) {
 	C.release_cache(cache.ptr)
 
 	// Release directory lock
-	_ = syscall.Flock(int(cache.lockfile.Fd()), syscall.LOCK_UN)
+	_ = unix.Flock(int(cache.lockfile.Fd()), unix.LOCK_UN)
 	cache.lockfile.Close()
 }
 

--- a/internal/api/lib.go
+++ b/internal/api/lib.go
@@ -82,9 +82,7 @@ func InitCache(dataDir string, supportedCapabilities []string, cacheSize uint32,
 func ReleaseCache(cache Cache) {
 	C.release_cache(cache.ptr)
 
-	// Release directory lock
-	_ = unix.Flock(int(cache.lockfile.Fd()), unix.LOCK_UN)
-	cache.lockfile.Close()
+	cache.lockfile.Close() // Also releases the file lock
 }
 
 func StoreCode(cache Cache, wasm []byte) ([]byte, error) {

--- a/lib.go
+++ b/lib.go
@@ -36,7 +36,8 @@ func NewVM(dataDir string, supportedCapabilities []string, memoryLimit uint32, p
 	return &VM{cache: cache, printDebug: printDebug}, nil
 }
 
-// Cleanup should be called when no longer using this to free resources on the rust-side
+// Cleanup should be called when no longer using this instances.
+// It frees resources in libwasmvm (the Rust part) and releases a lock in the base directory.
 func (vm *VM) Cleanup() {
 	api.ReleaseCache(vm.cache)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -147,7 +147,7 @@ type DenomUnit struct {
 type DecCoin struct {
 	// An amount in the base denom of the distributed token.
 	//
-	// Some chains have choosen atto (10^-18) for their token's base denomination. If we used `Decimal` here, we could only store 340282366920938463463.374607431768211455atoken which is 340.28 TOKEN.
+	// Some chains have chosen atto (10^-18) for their token's base denomination. If we used `Decimal` here, we could only store 340282366920938463463.374607431768211455atoken which is 340.28 TOKEN.
 	Amount string `json:"amount"`
 	Denom  string `json:"denom"`
 }


### PR DESCRIPTION
In the past we have seen cases in which multiple instaces ran on the same directory in parallel (especially test setups), leading to unreliable and hard to debug issues down the road.

- [x] Implementation
- [x] Add MIGRATING entry