### PR TITLE
Try sync.Map v2

### DIFF
--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -109,7 +109,7 @@ func TestInitCacheEmptyCapabilities(t *testing.T) {
 	ReleaseCache(cache)
 }
 
-func withCache(t *testing.T) (Cache, func()) {
+func withCache(t testing.TB) (Cache, func()) {
 	tmpdir, err := os.MkdirTemp("", "wasmvm-testing")
 	require.NoError(t, err)
 	cache, err := InitCache(tmpdir, TESTING_CAPABILITIES, TESTING_CACHE_SIZE, TESTING_MEMORY_LIMIT)
@@ -909,7 +909,7 @@ func TestReplyAndQuery(t *testing.T) {
 	require.Equal(t, events, val.Events)
 }
 
-func requireOkResponse(t *testing.T, res []byte, expectedMsgs int) {
+func requireOkResponse(t testing.TB, res []byte, expectedMsgs int) {
 	var result types.ContractResult
 	err := json.Unmarshal(res, &result)
 	require.NoError(t, err)
@@ -938,23 +938,23 @@ func createHackatomContract(t *testing.T, cache Cache) []byte {
 	return createContract(t, cache, "../../testdata/hackatom.wasm")
 }
 
-func createCyberpunkContract(t *testing.T, cache Cache) []byte {
+func createCyberpunkContract(t testing.TB, cache Cache) []byte {
 	return createContract(t, cache, "../../testdata/cyberpunk.wasm")
 }
 
-func createQueueContract(t *testing.T, cache Cache) []byte {
+func createQueueContract(t testing.TB, cache Cache) []byte {
 	return createContract(t, cache, "../../testdata/queue.wasm")
 }
 
-func createReflectContract(t *testing.T, cache Cache) []byte {
+func createReflectContract(t testing.TB, cache Cache) []byte {
 	return createContract(t, cache, "../../testdata/reflect.wasm")
 }
 
-func createFloaty2(t *testing.T, cache Cache) []byte {
+func createFloaty2(t testing.TB, cache Cache) []byte {
 	return createContract(t, cache, "../../testdata/floaty_2.0.wasm")
 }
 
-func createContract(t *testing.T, cache Cache, wasmFile string) []byte {
+func createContract(t testing.TB, cache Cache, wasmFile string) []byte {
 	wasm, err := os.ReadFile(wasmFile)
 	require.NoError(t, err)
 	checksum, err := StoreCode(cache, wasm)

--- a/internal/api/mocks.go
+++ b/internal/api/mocks.go
@@ -35,7 +35,7 @@ func MockEnv() types.Env {
 	}
 }
 
-func MockEnvBin(t *testing.T) []byte {
+func MockEnvBin(t testing.TB) []byte {
 	bin, err := json.Marshal(MockEnv())
 	require.NoError(t, err)
 	return bin
@@ -55,7 +55,7 @@ func MockInfoWithFunds(sender types.HumanAddress) types.MessageInfo {
 	}})
 }
 
-func MockInfoBin(t *testing.T, sender types.HumanAddress) []byte {
+func MockInfoBin(t testing.TB, sender types.HumanAddress) []byte {
 	bin, err := json.Marshal(MockInfoWithFunds(sender))
 	require.NoError(t, err)
 	return bin


### PR DESCRIPTION
A re-created version of https://github.com/CosmWasm/wasmvm/commit/d7829b96f9db7b130f21d9795c45cdc6d72a5bc1 for #322.

This seems to work overall, but I am not impressed by the timing imporvements this brings:


## Before (without sync.Map)

```
BenchmarkConcurrentIterators-10             1000          17665542 ns/op
BenchmarkConcurrentIterators-10             1000          17598419 ns/op
BenchmarkConcurrentIterators-10             1000          17232989 ns/op
BenchmarkConcurrentIterators-10             1000          17355900 ns/op
```

## After (with sync.Map)

```
BenchmarkConcurrentIterators-10             1000          16104471 ns/op
BenchmarkConcurrentIterators-10             1000          16180791 ns/op
```

Maybe some more realistic use case is needed to better evaluate performance but those ~7% in this aggressively paralized test on 10 cores is not really convincing me.
