### PR TITLE
Let StoreCode return gas cost

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"os"
 
 	wasmvm "github.com/CosmWasm/wasmvm"
@@ -44,7 +45,7 @@ func main() {
 		panic(err)
 	}
 
-	checksum, _, err := vm.StoreCode(bz)
+	checksum, _, err := vm.StoreCode(bz, math.MaxUint64)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -44,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	checksum, err := vm.StoreCode(bz)
+	checksum, _, err := vm.StoreCode(bz)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -21,6 +21,9 @@
   two `VM` instances operate on the same directory in parallel. This was
   unsupported before already but now leads to an error early on. When doing
   parallel testing, use a different directory for each instance.
+- `VM.StoreCode` now returns a `uint64` containing the gas cost in CosmWasm gas.
+  This was previously calculated in wasmd. The change brings consistency with
+  the other functions that cause gas usage.
 
 ## Renamings
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -21,9 +21,9 @@
   two `VM` instances operate on the same directory in parallel. This was
   unsupported before already but now leads to an error early on. When doing
   parallel testing, use a different directory for each instance.
-- `VM.StoreCode` now returns a `uint64` containing the gas cost in CosmWasm gas.
-  This was previously calculated in wasmd. The change brings consistency with
-  the other functions that cause gas usage.
+- `VM.StoreCode` now returns a `uint64` containing the gas cost in CosmWasm gas
+  and takes a gas limit as argument. This was previously calculated in wasmd.
+  The change brings consistency with the other functions that cause gas usage.
 
 ## Renamings
 

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -22,7 +22,7 @@ func TestIBC(t *testing.T) {
 	wasm, err := os.ReadFile(IBC_TEST_CONTRACT)
 	require.NoError(t, err)
 
-	checksum, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
 
 	code, err := vm.GetCode(checksum)
@@ -295,7 +295,7 @@ func TestAnalyzeCode(t *testing.T) {
 	// Store non-IBC contract
 	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
-	checksum, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
 	// and analyze
 	report, err := vm.AnalyzeCode(checksum)
@@ -307,7 +307,7 @@ func TestAnalyzeCode(t *testing.T) {
 	// Store IBC contract
 	wasm2, err := os.ReadFile(IBC_TEST_CONTRACT)
 	require.NoError(t, err)
-	checksum2, err := vm.StoreCode(wasm2)
+	checksum2, _, err := vm.StoreCode(wasm2)
 	require.NoError(t, err)
 	// and analyze
 	report2, err := vm.AnalyzeCode(checksum2)

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -22,7 +22,7 @@ func TestIBC(t *testing.T) {
 	wasm, err := os.ReadFile(IBC_TEST_CONTRACT)
 	require.NoError(t, err)
 
-	checksum, _, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 
 	code, err := vm.GetCode(checksum)
@@ -295,7 +295,7 @@ func TestAnalyzeCode(t *testing.T) {
 	// Store non-IBC contract
 	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
-	checksum, _, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 	// and analyze
 	report, err := vm.AnalyzeCode(checksum)
@@ -307,7 +307,7 @@ func TestAnalyzeCode(t *testing.T) {
 	// Store IBC contract
 	wasm2, err := os.ReadFile(IBC_TEST_CONTRACT)
 	require.NoError(t, err)
-	checksum2, _, err := vm.StoreCode(wasm2)
+	checksum2, _, err := vm.StoreCode(wasm2, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 	// and analyze
 	report2, err := vm.AnalyzeCode(checksum2)

--- a/lib.go
+++ b/lib.go
@@ -51,9 +51,10 @@ func (vm *VM) Cleanup() {
 // This function stores the code for that contract only once, but it can
 // be instantiated with custom inputs in the future.
 //
-// TODO: return gas cost? Add gas limit??? there is no metering here...
-func (vm *VM) StoreCode(code WasmCode) (Checksum, error) {
-	return api.StoreCode(vm.cache, code)
+// Returns both the checksum, as well as the gas cost of compilation (in CosmWasm Gas) or an error.
+func (vm *VM) StoreCode(code WasmCode) (Checksum, uint64, error) {
+	checksum, err := api.StoreCode(vm.cache, code)
+	return checksum, compileCosts(code), err
 }
 
 // StoreCodeUnchecked is the same as StoreCode but skips static validation checks.
@@ -523,6 +524,15 @@ func (vm *VM) IBCPacketTimeout(
 		return nil, gasReport.UsedInternally, err
 	}
 	return &result, gasReport.UsedInternally, nil
+}
+
+func compileCosts(code WasmCode) uint64 {
+	// CostPerByte is how much CosmWasm gas is charged *per byte* for compiling WASM code.
+	// Benchmarks and numbers (in SDK Gas) were discussed in:
+	// https://github.com/CosmWasm/wasmd/pull/634#issuecomment-938056803
+	const CostPerByte uint64 = 3 * 140_000
+
+	return CostPerByte * uint64(len(code))
 }
 
 func DeserializeResponse(gasLimit uint64, deserCost types.UFraction, gasReport *types.GasReport, data []byte, response any) error {

--- a/lib.go
+++ b/lib.go
@@ -53,7 +53,7 @@ func (vm *VM) Cleanup() {
 //
 // Returns both the checksum, as well as the gas cost of compilation (in CosmWasm Gas) or an error.
 func (vm *VM) StoreCode(code WasmCode, gasLimit uint64) (Checksum, uint64, error) {
-	gasCost := compileCosts(code)
+	gasCost := compileCost(code)
 	if gasLimit < gasCost {
 		return nil, gasCost, fmt.Errorf("insufficient gas to store contract (%d bytes)", len(code))
 	}
@@ -531,7 +531,7 @@ func (vm *VM) IBCPacketTimeout(
 	return &result, gasReport.UsedInternally, nil
 }
 
-func compileCosts(code WasmCode) uint64 {
+func compileCost(code WasmCode) uint64 {
 	// CostPerByte is how much CosmWasm gas is charged *per byte* for compiling WASM code.
 	// Benchmarks and numbers (in SDK Gas) were discussed in:
 	// https://github.com/CosmWasm/wasmd/pull/634#issuecomment-938056803

--- a/lib.go
+++ b/lib.go
@@ -55,7 +55,7 @@ func (vm *VM) Cleanup() {
 func (vm *VM) StoreCode(code WasmCode, gasLimit uint64) (Checksum, uint64, error) {
 	gasCost := compileCost(code)
 	if gasLimit < gasCost {
-		return nil, gasCost, fmt.Errorf("insufficient gas to store contract (%d bytes)", len(code))
+		return nil, gasCost, types.OutOfGasError{}
 	}
 
 	checksum, err := api.StoreCode(vm.cache, code)

--- a/lib.go
+++ b/lib.go
@@ -52,9 +52,14 @@ func (vm *VM) Cleanup() {
 // be instantiated with custom inputs in the future.
 //
 // Returns both the checksum, as well as the gas cost of compilation (in CosmWasm Gas) or an error.
-func (vm *VM) StoreCode(code WasmCode) (Checksum, uint64, error) {
+func (vm *VM) StoreCode(code WasmCode, gasLimit uint64) (Checksum, uint64, error) {
+	gasCost := compileCosts(code)
+	if gasLimit < gasCost {
+		return nil, gasCost, fmt.Errorf("insufficient gas to store contract (%d bytes)", len(code))
+	}
+
 	checksum, err := api.StoreCode(vm.cache, code)
-	return checksum, compileCosts(code), err
+	return checksum, gasCost, err
 }
 
 // StoreCodeUnchecked is the same as StoreCode but skips static validation checks.

--- a/lib_test.go
+++ b/lib_test.go
@@ -44,7 +44,7 @@ func withVM(t *testing.T) *VM {
 func createTestContract(t *testing.T, vm *VM, path string) Checksum {
 	wasm, err := os.ReadFile(path)
 	require.NoError(t, err)
-	checksum, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
 	return checksum
 }
@@ -56,7 +56,7 @@ func TestStoreCode(t *testing.T) {
 	{
 		wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 		require.NoError(t, err)
-		_, err = vm.StoreCode(wasm)
+		_, _, err = vm.StoreCode(wasm)
 		require.NoError(t, err)
 	}
 
@@ -64,7 +64,7 @@ func TestStoreCode(t *testing.T) {
 	{
 		wasm, err := os.ReadFile(CYBERPUNK_TEST_CONTRACT)
 		require.NoError(t, err)
-		_, err = vm.StoreCode(wasm)
+		_, _, err = vm.StoreCode(wasm)
 		require.NoError(t, err)
 	}
 
@@ -74,28 +74,28 @@ func TestStoreCode(t *testing.T) {
 		// hexdump -C < empty.wasm
 
 		wasm := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
-		_, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm)
 		require.ErrorContains(t, err, "Error during static Wasm validation: Wasm contract must contain exactly one memory")
 	}
 
 	// No Wasm
 	{
 		wasm := []byte("foobar")
-		_, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm)
 		require.ErrorContains(t, err, "Wasm bytecode could not be deserialized")
 	}
 
 	// Empty
 	{
 		wasm := []byte("")
-		_, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm)
 		require.ErrorContains(t, err, "Wasm bytecode could not be deserialized")
 	}
 
 	// Nil
 	{
 		var wasm []byte = nil
-		_, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm)
 		require.ErrorContains(t, err, "Null/Nil argument: wasm")
 	}
 }
@@ -106,7 +106,7 @@ func TestStoreCodeAndGet(t *testing.T) {
 	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 
-	checksum, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
 
 	code, err := vm.GetCode(checksum)
@@ -120,7 +120,7 @@ func TestRemoveCode(t *testing.T) {
 	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 
-	checksum, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm)
 	require.NoError(t, err)
 
 	err = vm.RemoveCode(checksum)

--- a/lib_test.go
+++ b/lib_test.go
@@ -44,7 +44,7 @@ func withVM(t *testing.T) *VM {
 func createTestContract(t *testing.T, vm *VM, path string) Checksum {
 	wasm, err := os.ReadFile(path)
 	require.NoError(t, err)
-	checksum, _, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 	return checksum
 }
@@ -56,7 +56,7 @@ func TestStoreCode(t *testing.T) {
 	{
 		wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 		require.NoError(t, err)
-		_, _, err = vm.StoreCode(wasm)
+		_, _, err = vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 		require.NoError(t, err)
 	}
 
@@ -64,7 +64,7 @@ func TestStoreCode(t *testing.T) {
 	{
 		wasm, err := os.ReadFile(CYBERPUNK_TEST_CONTRACT)
 		require.NoError(t, err)
-		_, _, err = vm.StoreCode(wasm)
+		_, _, err = vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 		require.NoError(t, err)
 	}
 
@@ -74,28 +74,28 @@ func TestStoreCode(t *testing.T) {
 		// hexdump -C < empty.wasm
 
 		wasm := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
-		_, _, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 		require.ErrorContains(t, err, "Error during static Wasm validation: Wasm contract must contain exactly one memory")
 	}
 
 	// No Wasm
 	{
 		wasm := []byte("foobar")
-		_, _, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 		require.ErrorContains(t, err, "Wasm bytecode could not be deserialized")
 	}
 
 	// Empty
 	{
 		wasm := []byte("")
-		_, _, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 		require.ErrorContains(t, err, "Wasm bytecode could not be deserialized")
 	}
 
 	// Nil
 	{
 		var wasm []byte = nil
-		_, _, err := vm.StoreCode(wasm)
+		_, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 		require.ErrorContains(t, err, "Null/Nil argument: wasm")
 	}
 }
@@ -106,7 +106,7 @@ func TestStoreCodeAndGet(t *testing.T) {
 	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 
-	checksum, _, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 
 	code, err := vm.GetCode(checksum)
@@ -120,7 +120,7 @@ func TestRemoveCode(t *testing.T) {
 	wasm, err := os.ReadFile(HACKATOM_TEST_CONTRACT)
 	require.NoError(t, err)
 
-	checksum, _, err := vm.StoreCode(wasm)
+	checksum, _, err := vm.StoreCode(wasm, TESTING_GAS_LIMIT)
 	require.NoError(t, err)
 
 	err = vm.RemoveCode(checksum)


### PR DESCRIPTION
closes #395

To be consistent with the entrypoints, it now returns the gas cost.
I used the [default gas multiplier and default compile cost](https://github.com/CosmWasm/wasmd/blob/894880666102b635a1955075fda16c53e58a0754/x/wasm/types/gas_register.go#L33) from wasmd (multiplier divided by 1000 ofc) to get the CosmWasm gas value. The cost calculation is also based on the [corresponding wasmd code](https://github.com/CosmWasm/wasmd/blob/894880666102b635a1955075fda16c53e58a0754/x/wasm/types/gas_register.go#L161-L166).