### PR TITLE
Omit `Payload` from json if empty

### DIFF
--- a/types/submessages.go
+++ b/types/submessages.go
@@ -71,7 +71,7 @@ type SubMsg struct {
 	// Unset/nil/null cannot be differentiated from empty data.
 	//
 	// On chains running CosmWasm 1.x this field will be ignored.
-	Payload []byte `json:"payload"`
+	Payload []byte `json:"payload,omitempty"`
 	// Gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
 	//
 	// Setting this to `None` means unlimited. Then the submessage execution can consume all gas of

--- a/types/submessages.go
+++ b/types/submessages.go
@@ -93,7 +93,7 @@ type Reply struct {
 	// Unset/nil/null cannot be differentiated from empty data.
 	//
 	// On chains running CosmWasm 1.x this field is never filled.
-	Payload []byte `json:"payload"`
+	Payload []byte `json:"payload,omitempty"`
 }
 
 // SubMsgResult is the raw response we return from wasmd after executing a SubMsg.

--- a/types/submessages_test.go
+++ b/types/submessages_test.go
@@ -38,6 +38,18 @@ func TestReplySerialization(t *testing.T) {
 	serialized, err := json.Marshal(&reply1)
 	require.NoError(t, err)
 	require.Equal(t, `{"gas_used":4312324,"id":75,"result":{"ok":{"events":[{"type":"hi","attributes":[{"key":"si","value":"claro"}]}],"data":"PwCqXKs=","msg_responses":[{"type_url":"/cosmos.bank.v1beta1.MsgSendResponse","value":""}]}},"payload":"cGF5bG9hZA=="}`, string(serialized))
+
+	withoutPayload := Reply{
+		GasUsed: 4312324,
+		ID:      75,
+		Result: SubMsgResult{
+			Err: "some error",
+		},
+	}
+	serialized2, err := json.Marshal(&withoutPayload)
+	require.NoError(t, err)
+	require.Equal(t, `{"gas_used":4312324,"id":75,"result":{"error": "some error"}}`, string(serialized2))
+
 }
 
 func TestSubMsgResponseSerialization(t *testing.T) {

--- a/types/submessages_test.go
+++ b/types/submessages_test.go
@@ -48,8 +48,7 @@ func TestReplySerialization(t *testing.T) {
 	}
 	serialized2, err := json.Marshal(&withoutPayload)
 	require.NoError(t, err)
-	require.Equal(t, `{"gas_used":4312324,"id":75,"result":{"error": "some error"}}`, string(serialized2))
-
+	require.Equal(t, `{"gas_used":4312324,"id":75,"result":{"error":"some error"}}`, string(serialized2))
 }
 
 func TestSubMsgResponseSerialization(t *testing.T) {


### PR DESCRIPTION
The Rust side expects either a valid `Binary` (i.e. some valid string) or no field at all, but the current version would produce a `null` value, which fails when deserializing in Rust.
See also https://github.com/CosmWasm/cosmwasm/pull/2027 for the corresponding fix in the go generator.