### PR TITLE
Check goimports in golangci-lint

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -28,7 +28,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.55.2
+          version: v1.56.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - gofumpt
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/CosmWasm/wasmvm

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,11 @@ test-alpine: release-build-alpine create-tester-image
 format:
 	find . -name '*.go' -type f | xargs gofumpt -w -s
 	find . -name '*.go' -type f | xargs misspell -w
-	find . -name '*.go' -type f | xargs goimports -w -local github.com/CosmWasm/wasmvm
 
 .PHONY: lint
 lint:
 	golangci-lint run
+
+.PHONY: lint-fix
+lint-fix:
+	golangci-lint run --fix

--- a/lib_no_cgo_test.go
+++ b/lib_no_cgo_test.go
@@ -3,8 +3,9 @@ package cosmwasm
 import (
 	"testing"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/CosmWasm/wasmvm/v2/types"
 )
 
 func TestCreateChecksum(t *testing.T) {


### PR DESCRIPTION
On latest main there is a goimports formatting flaw that is not checked. Instead of adding more tools we can use the linter and lint fixer to handle those things for us.