### PR TITLE
chore: fix duplicate word repetition in CreateChecksum error return

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -52,7 +52,7 @@ func CreateChecksum(wasm []byte) (Checksum, error) {
 	// magic number for Wasm is "\0asm"
 	// See https://webassembly.github.io/spec/core/binary/modules.html#binary-module
 	if !bytes.Equal(wasm[:4], []byte("\x00\x61\x73\x6D")) {
-		return Checksum{}, fmt.Errorf("Wasm bytes do not not start with Wasm magic number")
+		return Checksum{}, fmt.Errorf("Wasm bytes do not start with Wasm magic number")
 	}
 	hash := sha256.Sum256(wasm)
 	return Checksum(hash[:]), nil

--- a/lib_test.go
+++ b/lib_test.go
@@ -29,5 +29,5 @@ func TestCreateChecksum(t *testing.T) {
 
 	// Text file fails
 	_, err = CreateChecksum([]byte("Hello world"))
-	require.ErrorContains(t, err, "do not not start with Wasm magic number")
+	require.ErrorContains(t, err, "do not start with Wasm magic number")
 }


### PR DESCRIPTION
Surfaced from somebody removing duplicate words in a PR to ibc-go which broke one of our tests in 08-wasm.
I put it back for now so that tests continue to all pass, but figured I'd flag the word repetition here and PR it.
