### PR TITLE
Add compile time type assertions for `hasSubMessages` interface

### DIFF
--- a/lib_libwasmvm.go
+++ b/lib_libwasmvm.go
@@ -548,9 +548,11 @@ type hasSubMessages interface {
 
 // make sure the types implement the interface
 // cannot put these next to the types, as the interface is private
-var _ hasSubMessages = (*types.IBCBasicResult)(nil)
-var _ hasSubMessages = (*types.IBCReceiveResult)(nil)
-var _ hasSubMessages = (*types.ContractResult)(nil)
+var (
+	_ hasSubMessages = (*types.IBCBasicResult)(nil)
+	_ hasSubMessages = (*types.IBCReceiveResult)(nil)
+	_ hasSubMessages = (*types.ContractResult)(nil)
+)
 
 func DeserializeResponse(gasLimit uint64, deserCost types.UFraction, gasReport *types.GasReport, data []byte, response any) error {
 	gasForDeserialization := deserCost.Mul(uint64(len(data))).Floor()

--- a/lib_libwasmvm.go
+++ b/lib_libwasmvm.go
@@ -546,6 +546,12 @@ type hasSubMessages interface {
 	SubMessages() []types.SubMsg
 }
 
+// make sure the types implement the interface
+// cannot put these next to the types, as the interface is private
+var _ hasSubMessages = (*types.IBCBasicResult)(nil)
+var _ hasSubMessages = (*types.IBCReceiveResult)(nil)
+var _ hasSubMessages = (*types.ContractResult)(nil)
+
 func DeserializeResponse(gasLimit uint64, deserCost types.UFraction, gasReport *types.GasReport, data []byte, response any) error {
 	gasForDeserialization := deserCost.Mul(uint64(len(data))).Floor()
 	if gasLimit < gasForDeserialization+gasReport.UsedInternally {


### PR DESCRIPTION
These just make sure that we get a compiler error if we ever change the interface.