### PR TITLE
Update builder to Rust 1.81

### DIFF
--- a/builders/Dockerfile.alpine
+++ b/builders/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1.80.0-alpine
+FROM --platform=linux/amd64 rust:1.81.0-alpine
 
 RUN apk add --no-cache ca-certificates build-base
 

--- a/builders/Dockerfile.cross
+++ b/builders/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1.80.0-bookworm
+FROM --platform=linux/amd64 rust:1.81.0-bookworm
 
 # Install build dependencies
 RUN apt-get update \

--- a/builders/Dockerfile.debian
+++ b/builders/Dockerfile.debian
@@ -8,12 +8,12 @@ RUN apt update -y \
 
 # GET FROM https://github.com/rust-lang/docker-rust-nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH
 
 RUN wget --no-verbose "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
   && chmod +x rustup-init \
-  && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.80.0 \
+  && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.81.0 \
   && rm rustup-init \
   && chmod -R a+w $RUSTUP_HOME $CARGO_HOME \
   && rustup --version \

--- a/builders/README.md
+++ b/builders/README.md
@@ -1,6 +1,6 @@
 # Cross Compilation Scripts
 
-As this library is targetting go developers, we cannot assume a properly set up
+As this library is targeting go developers, we cannot assume a properly set up
 rust environment on their system. Further, when importing this library, there is
 no clean way to add a `libwasmvm.{so,dll,dylib}`. It needs to be committed with
 the tagged (go) release in order to be easily usable.
@@ -23,7 +23,7 @@ See those DockerHub repos for all available versions of the builder images.
 
 **Unreleased**
 
-- Update Rust to 1.80.0.
+- Update Rust to 1.81.0.
 - Update Dockerfile.cross from Debian Bullseye to Bookworm ([#533])
 - Rename `.cargo/config` to `.cargo/config.toml` to silence warning
 


### PR DESCRIPTION
Wasmer is planning to require 1.81 soon, so we might as well update to that now before releasing the new builder in #551