### PR TITLE
Lock cargo-audit CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
             - v3-libwasmvm_audit-rust:1.81.0-
       - run:
           name: Install cargo-audit
-          command: cargo install --debug cargo-audit --version 0.17.6 --locked
+          command: cargo install --debug cargo-audit --version 0.21.0 --locked
       - run:
           name: Run cargo-audit
           working_directory: libwasmvm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
             - v3-libwasmvm_audit-rust:1.81.0-
       - run:
           name: Install cargo-audit
-          command: cargo install --debug cargo-audit --version 0.17.6
+          command: cargo install --debug cargo-audit --version 0.17.6 --locked
       - run:
           name: Run cargo-audit
           working_directory: libwasmvm


### PR DESCRIPTION
This makes sure that subsequent runs of the CI job always use the same dependencies for building cargo-audit to avoid the job failing because some dependency of cargo-audit did an update that now requires a newer Rust version.
As can be seen in #602 

I also updated cargo-audit while I was at it.

@Mergifyio backport release/1.5 release/2.0 release/2.1 release/2.2