### PR TITLE
Fix builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,7 @@ bench:
 # Creates a release build in a containerized build environment of the static library for Alpine Linux (.a)
 release-build-alpine:
 	# build the muslc *.a file
-	docker run --rm -v $(shell pwd)/libwasmvm:/code \
-		-e CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
-		-e CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
-		-e CFLAGS_aarch64_unknown_linux_musl="" \
-		$(BUILDERS_PREFIX)-alpine
+	docker run --rm -v $(shell pwd)/libwasmvm:/code $(BUILDERS_PREFIX)-alpine
 	cp libwasmvm/artifacts/libwasmvm_muslc.x86_64.a internal/api
 	cp libwasmvm/artifacts/libwasmvm_muslc.aarch64.a internal/api
 	make update-bindings

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Builds the Rust library libwasmvm
-BUILDERS_PREFIX := cosmwasm/libwasmvm-builder:0102
+BUILDERS_PREFIX := cosmwasm/libwasmvm-builder:0103
 # Contains a full Go dev environment including CGO support in order to run Go tests on the built shared library
 # This image is currently not published.
 ALPINE_TESTER := cosmwasm/alpine-tester:local
@@ -76,7 +76,11 @@ bench:
 # Creates a release build in a containerized build environment of the static library for Alpine Linux (.a)
 release-build-alpine:
 	# build the muslc *.a file
-	docker run --rm -v $(shell pwd)/libwasmvm:/code $(BUILDERS_PREFIX)-alpine
+	docker run --rm -v $(shell pwd)/libwasmvm:/code \
+		-e CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+		-e CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+		-e CFLAGS_aarch64_unknown_linux_musl="" \
+		$(BUILDERS_PREFIX)-alpine
 	cp libwasmvm/artifacts/libwasmvm_muslc.x86_64.a internal/api
 	cp libwasmvm/artifacts/libwasmvm_muslc.aarch64.a internal/api
 	make update-bindings

--- a/builders/Dockerfile.alpine
+++ b/builders/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 rust:1.82.0-alpine
 
-RUN apk add --no-cache ca-certificates build-base
+RUN apk add --no-cache ca-certificates build-base llvm17-dev clang17-static
 
 # Install C compiler for cross-compilation. This is required by
 # Wasmer in https://github.com/wasmerio/wasmer/blob/2.2.1/lib/vm/build.rs.

--- a/builders/Dockerfile.debian
+++ b/builders/Dockerfile.debian
@@ -4,7 +4,7 @@
 FROM --platform=linux/amd64 debian:11-slim
 
 RUN apt update -y \
-  && apt install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu wget
+  && apt install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu wget clang
 
 # GET FROM https://github.com/rust-lang/docker-rust-nightly
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/builders/Makefile
+++ b/builders/Makefile
@@ -1,6 +1,6 @@
 # Versioned by a simple counter that is not bound to a specific CosmWasm version
 # See builders/README.md
-BUILDERS_PREFIX := cosmwasm/libwasmvm-builder:0102
+BUILDERS_PREFIX := cosmwasm/libwasmvm-builder:0103
 
 .PHONY: docker-image-debian
 docker-image-debian:

--- a/builders/guest/build_gnu_aarch64.sh
+++ b/builders/guest/build_gnu_aarch64.sh
@@ -7,8 +7,6 @@ export TARGET_DIR="/target" # write to /target in the guest's file system to avo
 # No stripping implemented (see https://github.com/CosmWasm/wasmvm/issues/222#issuecomment-2260007943).
 
 echo "Starting aarch64-unknown-linux-gnu build"
-export CC=clang
-export CXX=clang++
 export qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 export CC_aarch64_unknown_linux_gnu=clang
 export AR_aarch64_unknown_linux_gnu=llvm-ar

--- a/builders/guest/build_muslc.sh
+++ b/builders/guest/build_muslc.sh
@@ -7,9 +7,8 @@ export TARGET_DIR="/target" # write to /target in the guest's file system to avo
 # No stripping implemented (see https://github.com/CosmWasm/wasmvm/issues/222#issuecomment-2260007943).
 
 echo "Starting aarch64-unknown-linux-musl build"
-export CC=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+export CC_aarch64_unknown_linux_musl=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
 cargo build --release --target-dir="$TARGET_DIR" --target aarch64-unknown-linux-musl --example wasmvmstatic
-unset CC
 
 echo "Starting x86_64-unknown-linux-musl build"
 cargo build --release --target-dir="$TARGET_DIR" --target x86_64-unknown-linux-musl --example wasmvmstatic

--- a/docs/COMPILER_VERSIONS.md
+++ b/docs/COMPILER_VERSIONS.md
@@ -63,6 +63,6 @@ We currently use the following version:
 
 | Type                     | Rust version | Note                              |
 | ------------------------ | ------------ | --------------------------------- |
-| Production Rust compiler | 1.82.0       | Builders version 0102             |
-| Min Rust compiler        | 1.82.0       | Supports builder versions >= 0102 |
+| Production Rust compiler | 1.82.0       | Builders version 0103             |
+| Min Rust compiler        | 1.82.0       | Supports builder versions >= 0103 |
 | Tooling Rust compiler    | 1.81.0       |                                   |


### PR DESCRIPTION
After updating in #621, the alpine builder was [failing](https://github.com/CosmWasm/wasmvm/commit/63f03268697060a473dde29fc896277d4da023b8). This fixes the builders.

I'll release when this gets approved.