### PR TITLE
chore: fix function name in comment

### DIFF
--- a/lib_libwasmvm.go
+++ b/lib_libwasmvm.go
@@ -678,7 +678,7 @@ func (vm *VM) IBCDestinationCallback(
 	return &result, gasReport.UsedInternally, nil
 }
 
-// IBCPacketReceive is available on IBC-enabled contracts and is called when an incoming
+// IBC2PacketReceive is available on IBC-enabled contracts and is called when an incoming
 // packet is received on a channel belonging to this contract
 func (vm *VM) IBC2PacketReceive(
 	checksum Checksum,


### PR DESCRIPTION
fix function name in comment