### PR TITLE
Update Go and Nix tooling to latest versions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ a.out
 
 # macOS
 .DS_Store
+
+# direnv Nix stuff
+.direnv/

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,43 @@
+run:
+  tests: true
+
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - gofumpt
+    - gci
+    - testifylint
+    - errcheck
+    - thelper
+
+linters-settings:
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/cosmos/cosmos-sdk) # Custom section: groups all imports with the specified Prefix.
+      - prefix(github.com/cosmos/ibc-go)
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+      - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+    # Skip generated files.
+    # Default: true
+    skip-generated: false
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true
+    # Drops lexical ordering for custom sections.
+    # Default: false
+    no-lex-order: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,43 +1,62 @@
+version: "2"
+
 run:
   tests: true
 
 linters:
-  # Enable specific linter
+  # Enable specific linters
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
-    - gofumpt
-    - gci
+    - misspell
     - testifylint
-    - errcheck
     - thelper
-
-linters-settings:
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/cosmos/cosmos-sdk) # Custom section: groups all imports with the specified Prefix.
-      - prefix(github.com/cosmos/ibc-go)
-      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
-      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
-      - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
-      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
-    # Skip generated files.
-    # Default: true
-    skip-generated: false
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
-    # Drops lexical ordering for custom sections.
-    # Default: false
-    no-lex-order: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      # Section configuration to compare against.
+      # Section names are case-insensitive and may contain parameters in ().
+      # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
+      # If `custom-order` is `true`, it follows the order of `sections` option.
+      # Default: ["standard", "default"]
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/cosmos/cosmos-sdk) # Custom section: groups all imports with the specified Prefix.
+        - prefix(github.com/cosmos/ibc-go)
+        - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+        - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+        - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+        - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+      # Enable custom order of sections.
+      # If `true`, make the section order the same as the order of `sections`.
+      # Default: false
+      custom-order: true
+      # Drops lexical ordering for custom sections.
+      # Default: false
+      no-lex-order: true
+  exclusions:
+    # Skip generated files.
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,7 @@ test-alpine: release-build-alpine create-tester-image
 
 .PHONY: format
 format:
-	find . -name '*.go' -type f | xargs gofumpt -w -s
-	find . -name '*.go' -type f | xargs misspell -w
+	find . -name '*.go' -type f | xargs gofumpt -w
 
 .PHONY: lint
 lint:

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710631334,
-        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     rust-overlay = {
       inputs = {
         flake-utils.follows = "flake-utils";
@@ -13,8 +13,15 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay } @ inputs:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+    }@inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
@@ -22,7 +29,7 @@
         };
       in
       {
-        formatter = pkgs.nixpkgs-fmt;
+        formatter = pkgs.nixfmt-rfc-style;
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -302,7 +302,7 @@ func TestAnalyzeCode(t *testing.T) {
 	report, err := vm.AnalyzeCode(checksum)
 	require.NoError(t, err)
 	require.False(t, report.HasIBCEntryPoints)
-	require.Equal(t, "", report.RequiredCapabilities)
+	require.Empty(t, report.RequiredCapabilities)
 	require.Equal(t, uint64(42), *report.ContractMigrateVersion)
 
 	// Store IBC contract

--- a/internal/api/iterator.go
+++ b/internal/api/iterator.go
@@ -65,7 +65,7 @@ func storeIterator(callID uint64, it types.Iterator, frameLenLimit int) (uint64,
 
 	new_index := len(iteratorFrames[callID])
 	if new_index >= frameLenLimit {
-		return 0, fmt.Errorf("Reached iterator limit (%d)", frameLenLimit)
+		return 0, fmt.Errorf("reached iterator limit (%d)", frameLenLimit)
 	}
 
 	// store at array position `new_index`

--- a/internal/api/iterator_test.go
+++ b/internal/api/iterator_test.go
@@ -192,7 +192,7 @@ func TestQueueIteratorSimple(t *testing.T) {
 	var qResult types.QueryResult
 	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult.Err)
+	require.Empty(t, qResult.Err)
 	require.Equal(t, `{"sum":39}`, string(qResult.Ok))
 
 	// query reduce (multiple iterators at once)
@@ -202,7 +202,7 @@ func TestQueueIteratorSimple(t *testing.T) {
 	var reduced types.QueryResult
 	err = json.Unmarshal(data, &reduced)
 	require.NoError(t, err)
-	require.Equal(t, "", reduced.Err)
+	require.Empty(t, reduced.Err)
 	require.JSONEq(t, `{"counters":[[17,22],[22,0]]}`, string(reduced.Ok))
 }
 
@@ -231,7 +231,7 @@ func TestQueueIteratorRaces(t *testing.T) {
 		var reduced types.QueryResult
 		err = json.Unmarshal(data, &reduced)
 		require.NoError(t, err)
-		require.Equal(t, "", reduced.Err)
+		require.Empty(t, reduced.Err)
 		require.Equal(t, fmt.Sprintf(`{"counters":%s}`, expected), string(reduced.Ok))
 	}
 
@@ -283,7 +283,7 @@ func TestQueueIteratorLimit(t *testing.T) {
 	require.NoError(t, err)
 	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult.Err)
+	require.Empty(t, qResult.Err)
 	require.Equal(t, `{}`, string(qResult.Ok))
 
 	// Open 35000 iterators

--- a/internal/api/lib.go
+++ b/internal/api/lib.go
@@ -48,26 +48,26 @@ func InitCache(config types.VMConfig) (Cache, error) {
 	// libwasmvm would create this directory too but we need it earlier for the lockfile
 	err := os.MkdirAll(config.Cache.BaseDir, 0o755)
 	if err != nil {
-		return Cache{}, fmt.Errorf("Could not create base directory")
+		return Cache{}, fmt.Errorf("could not create base directory")
 	}
 
 	lockfile, err := os.OpenFile(filepath.Join(config.Cache.BaseDir, "exclusive.lock"), os.O_WRONLY|os.O_CREATE, 0o666)
 	if err != nil {
-		return Cache{}, fmt.Errorf("Could not open exclusive.lock")
+		return Cache{}, fmt.Errorf("could not open exclusive.lock")
 	}
 	_, err = lockfile.WriteString("This is a lockfile that prevent two VM instances to operate on the same directory in parallel.\nSee codebase at github.com/CosmWasm/wasmvm for more information.\nSafety first – brought to you by Confio ❤️\n")
 	if err != nil {
-		return Cache{}, fmt.Errorf("Error writing to exclusive.lock")
+		return Cache{}, fmt.Errorf("error writing to exclusive.lock")
 	}
 
 	err = unix.Flock(int(lockfile.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 	if err != nil {
-		return Cache{}, fmt.Errorf("Could not lock exclusive.lock. Is a different VM running in the same directory already?")
+		return Cache{}, fmt.Errorf("could not lock exclusive.lock. Is a different VM running in the same directory already?")
 	}
 
 	configBytes, err := json.Marshal(config)
 	if err != nil {
-		return Cache{}, fmt.Errorf("Could not serialize config")
+		return Cache{}, fmt.Errorf("could not serialize config")
 	}
 	configView := makeView(configBytes)
 	defer runtime.KeepAlive(configBytes)

--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -585,7 +585,7 @@ func TestInstantiate(t *testing.T) {
 	var result types.ContractResult
 	err = json.Unmarshal(res, &result)
 	require.NoError(t, err)
-	require.Equal(t, "", result.Err)
+	require.Empty(t, result.Err)
 	require.Empty(t, result.Ok.Messages)
 }
 
@@ -631,7 +631,7 @@ func TestExecute(t *testing.T) {
 	var result types.ContractResult
 	err = json.Unmarshal(res, &result)
 	require.NoError(t, err)
-	require.Equal(t, "", result.Err)
+	require.Empty(t, result.Err)
 	require.Len(t, result.Ok.Messages, 1)
 	// Ensure we got our custom event
 	require.Len(t, result.Ok.Events, 1)
@@ -937,7 +937,7 @@ func TestMigrate(t *testing.T) {
 	var qResult types.QueryResult
 	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult.Err)
+	require.Empty(t, qResult.Err)
 	require.JSONEq(t, `{"verifier":"fred"}`, string(qResult.Ok))
 
 	// migrate to a new verifier - alice
@@ -951,7 +951,7 @@ func TestMigrate(t *testing.T) {
 	var qResult2 types.QueryResult
 	err = json.Unmarshal(data, &qResult2)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult2.Err)
+	require.Empty(t, qResult2.Err)
 	require.JSONEq(t, `{"verifier":"alice"}`, string(qResult2.Ok))
 }
 
@@ -992,7 +992,7 @@ func TestMultipleInstances(t *testing.T) {
 
 	// succeed to execute store1 with fred
 	resp = exec(t, cache, checksum, "fred", store1, api, querier, 0x15fce67)
-	require.Equal(t, "", resp.Err)
+	require.Empty(t, resp.Err)
 	require.Len(t, resp.Ok.Messages, 1)
 	attributes := resp.Ok.Attributes
 	require.Len(t, attributes, 2)
@@ -1001,7 +1001,7 @@ func TestMultipleInstances(t *testing.T) {
 
 	// succeed to execute store2 with mary
 	resp = exec(t, cache, checksum, "mary", store2, api, querier, 0x160131d)
-	require.Equal(t, "", resp.Err)
+	require.Empty(t, resp.Err)
 	require.Len(t, resp.Ok.Messages, 1)
 	attributes = resp.Ok.Attributes
 	require.Len(t, attributes, 2)
@@ -1042,7 +1042,7 @@ func TestSudo(t *testing.T) {
 	var result types.ContractResult
 	err = json.Unmarshal(res, &result)
 	require.NoError(t, err)
-	require.Equal(t, "", result.Err)
+	require.Empty(t, result.Err)
 	require.Len(t, result.Ok.Messages, 1)
 	dispatch := result.Ok.Messages[0].Msg
 	require.NotNil(t, dispatch.Bank, "%#v", dispatch)
@@ -1097,7 +1097,7 @@ func TestDispatchSubmessage(t *testing.T) {
 	var result types.ContractResult
 	err = json.Unmarshal(res, &result)
 	require.NoError(t, err)
-	require.Equal(t, "", result.Err)
+	require.Empty(t, result.Err)
 	require.Len(t, result.Ok.Messages, 1)
 	dispatch := result.Ok.Messages[0]
 	assert.Equal(t, id, dispatch.ID)
@@ -1180,7 +1180,7 @@ func requireOkResponse(tb testing.TB, res []byte, expectedMsgs int) {
 	var result types.ContractResult
 	err := json.Unmarshal(res, &result)
 	require.NoError(tb, err)
-	require.Equal(tb, "", result.Err)
+	require.Empty(tb, result.Err)
 	require.Len(tb, result.Ok.Messages, expectedMsgs)
 }
 
@@ -1293,7 +1293,7 @@ func TestQuery(t *testing.T) {
 	var qResult types.QueryResult
 	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult.Err)
+	require.Empty(t, qResult.Err)
 	require.JSONEq(t, `{"verifier":"fred"}`, string(qResult.Ok))
 }
 
@@ -1319,7 +1319,7 @@ func TestHackatomQuerier(t *testing.T) {
 	var qResult types.QueryResult
 	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult.Err)
+	require.Empty(t, qResult.Err)
 	var balances types.AllBalancesResponse
 	err = json.Unmarshal(qResult.Ok, &balances)
 	require.NoError(t, err)
@@ -1371,7 +1371,7 @@ func TestCustomReflectQuerier(t *testing.T) {
 	var qResult types.QueryResult
 	err = json.Unmarshal(data, &qResult)
 	require.NoError(t, err)
-	require.Equal(t, "", qResult.Err)
+	require.Empty(t, qResult.Err)
 
 	var response CapitalizedResponse
 	err = json.Unmarshal(qResult.Ok, &response)
@@ -1468,7 +1468,7 @@ func TestFloats(t *testing.T) {
 				result = debugStr(response)
 			}
 			// add the result to the hash
-			hasher.Write([]byte(fmt.Sprintf("%s%d%s", instr, seed, result)))
+			fmt.Fprintf(hasher, "%s%d%s", instr, seed, result)
 		}
 	}
 

--- a/internal/api/mocks.go
+++ b/internal/api/mocks.go
@@ -533,7 +533,7 @@ func (q ReflectCustom) Query(request json.RawMessage) ([]byte, error) {
 	} else if query.Capitalized != nil {
 		resp.Msg = strings.ToUpper(query.Capitalized.Text)
 	} else {
-		return nil, errors.New("Unsupported query")
+		return nil, errors.New("unsupported query")
 	}
 	return json.Marshal(resp)
 }

--- a/lib.go
+++ b/lib.go
@@ -44,15 +44,15 @@ func LibwasmvmVersion() (string, error) {
 // to avoid accidental misusage.
 func CreateChecksum(wasm []byte) (Checksum, error) {
 	if len(wasm) == 0 {
-		return Checksum{}, fmt.Errorf("Wasm bytes nil or empty")
+		return Checksum{}, fmt.Errorf("wasm bytes nil or empty")
 	}
 	if len(wasm) < 4 {
-		return Checksum{}, fmt.Errorf("Wasm bytes shorter than 4 bytes")
+		return Checksum{}, fmt.Errorf("wasm bytes shorter than 4 bytes")
 	}
 	// magic number for Wasm is "\0asm"
 	// See https://webassembly.github.io/spec/core/binary/modules.html#binary-module
 	if !bytes.Equal(wasm[:4], []byte("\x00\x61\x73\x6D")) {
-		return Checksum{}, fmt.Errorf("Wasm bytes do not start with Wasm magic number")
+		return Checksum{}, fmt.Errorf("wasm bytes do not start with Wasm magic number")
 	}
 	hash := sha256.Sum256(wasm)
 	return Checksum(hash[:]), nil

--- a/lib_libwasmvm.go
+++ b/lib_libwasmvm.go
@@ -737,7 +737,7 @@ var (
 func DeserializeResponse(gasLimit uint64, deserCost types.UFraction, gasReport *types.GasReport, data []byte, response any) error {
 	gasForDeserialization := deserCost.Mul(uint64(len(data))).Floor()
 	if gasLimit < gasForDeserialization+gasReport.UsedInternally {
-		return fmt.Errorf("Insufficient gas left to deserialize contract execution result (%d bytes)", len(data))
+		return fmt.Errorf("insufficient gas left to deserialize contract execution result (%d bytes)", len(data))
 	}
 	gasReport.UsedInternally += gasForDeserialization
 	gasReport.Remaining -= gasForDeserialization

--- a/types/msg_test.go
+++ b/types/msg_test.go
@@ -23,7 +23,7 @@ func TestWasmMsgInstantiateSerialization(t *testing.T) {
 	require.Nil(t, msg.ClearAdmin)
 	require.NotNil(t, msg.Instantiate)
 
-	require.Equal(t, "", msg.Instantiate.Admin)
+	require.Empty(t, msg.Instantiate.Admin)
 	require.Equal(t, uint64(7897), msg.Instantiate.CodeID)
 	require.JSONEq(t, `{"claim":{}}`, string(msg.Instantiate.Msg))
 	require.Equal(t, Array[Coin]{
@@ -65,7 +65,7 @@ func TestWasmMsgInstantiate2Serialization(t *testing.T) {
 	require.Nil(t, msg.ClearAdmin)
 	require.NotNil(t, msg.Instantiate2)
 
-	require.Equal(t, "", msg.Instantiate2.Admin)
+	require.Empty(t, msg.Instantiate2.Admin)
 	require.Equal(t, uint64(7897), msg.Instantiate2.CodeID)
 	require.JSONEq(t, `{"claim":{}}`, string(msg.Instantiate2.Msg))
 	require.Equal(t, Array[Coin]{


### PR DESCRIPTION
This PR updates the Go tooling (i.e. `golangci-lint`) to the latest version and removes `misspell` as a separate step.

This is done because of an update needed for the Nix flake to be able to build the Rust part of the project since the compiler was a little too out of date.

God, Nix is a pain in the ass with these kinds of things..

Made this a separate PR since mixing this with the IBCv2 things I was working on would have been hell to review.

---

Rationate of the changes:

## Removal of `misspell`

The original `misspell` has been deprecated for a while now. A continously updated fork is a default plugin in `golangci-lint` now.

## Update of `golangci-lint`

Nix only packages the most recent version, so the update was needed. The configuration file is updated in accordance and `misspell` is added to the enabled linters.

I migrated the configuration to version 2, as required by the recent `golangci-lint` version. Luckily they have a workflow to automatically convert the configuration. After running the checks, I couldn't see any breakage.

I also added some linebreaks and tried to transfer the comments as accurately as I could.

## Code updates

Those are just updates according to the linters of the updated `golangci-lint` (complaining about empty strings in `require.Equal`, and complaints about error messages being capitalized).  
So essentially non-invaisive changes done to satisfy static checks n' everything.

## Introduction of `direnv`

`direnv` is used pretty extensively with Nix projects since it just simplifies the workflow of getting VS Code to work with Nix packages, and it removes one step from every time a project is opened (namely: running `nix develop`).

It's also a non-invaisive addition. Just an `.envrc` file with the contents `use flake` and an addition to the `.gitignore`.