### PR TITLE
Improve panic messages when VM panicks

### DIFF
--- a/libwasmvm/src/handle_vm_panic.rs
+++ b/libwasmvm/src/handle_vm_panic.rs
@@ -5,8 +5,14 @@ use std::any::Any;
 /// We want to provide as much debug information as possible
 /// as those cases are not expected to happen during healthy operations.
 pub fn handle_vm_panic(what: &str, err: Box<dyn Any + Send + 'static>) {
+    let err = match (err.downcast_ref::<&str>(), err.downcast_ref::<String>()) {
+        (Some(str), ..) => *str,
+        (.., Some(str)) => str,
+        (None, None) => "[unusable panic payload]",
+    };
+
     eprintln!("Panic in {what}:");
-    eprintln!("{err:?}"); // Does not show useful information, see https://users.rust-lang.org/t/return-value-from-catch-unwind-is-a-useless-any/89134/6
+    eprintln!("{err:?}");
     eprintln!(
         "This indicates a panic in during the operations of libwasmvm/cosmwasm-vm.
 Such panics must not happen and are considered bugs. If you see this in any real-world or
@@ -27,6 +33,15 @@ mod tests {
     fn handle_vm_panic_works() {
         fn nice_try() {
             panic!("oh no!");
+        }
+        let err = catch_unwind(nice_try).unwrap_err();
+        handle_vm_panic("nice_try", err);
+    }
+
+    #[test]
+    fn can_handle_random_payloads() {
+        fn nice_try() {
+            std::panic::panic_any(());
         }
         let err = catch_unwind(nice_try).unwrap_err();
         handle_vm_panic("nice_try", err);


### PR DESCRIPTION
Closes #570 

Attempts to downcast the value into either a string slice or a string. That way we can obtain better error messages.  
Works with `.unwrap()` and such as well :D 