### PR TITLE
Update flake and fix features

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,19 +43,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1710814282,
-        "narHash": "sha256-nWaKhMQackiO0M8504HSx/E7I76C2r0/g4wqZf4hp24=",
+        "lastModified": 1744770893,
+        "narHash": "sha256-RMyTyFHN3w8zwfpgvcfRHQ4vX4zTqhuZbif/MXROtx8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8c72f33c23c8e537dd59088c4560222c43eedaca",
+        "rev": "1633514603fc0ed15ea0aef7327e26736ec003c0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     rust-overlay = {
       inputs = {
-        flake-utils.follows = "flake-utils";
         nixpkgs.follows = "nixpkgs";
       };
       url = "github:oxalica/rust-overlay";
@@ -27,6 +26,10 @@
         pkgs = import nixpkgs {
           inherit overlays system;
         };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" ];
+        };
       in
       {
         formatter = pkgs.nixfmt-rfc-style;
@@ -36,7 +39,7 @@
             go
             gofumpt
             golangci-lint
-            rust-bin.stable.latest.default
+            rustToolchain
           ];
         };
       }


### PR DESCRIPTION
The Rust version was still out of date. Somehow?

Anyway, this PR updates the revision used of `rust-overlay` and adds the `rust-src` feature for Rust Analyzer