### PR TITLE
Use Display representation of err: &str

### DIFF
--- a/libwasmvm/src/handle_vm_panic.rs
+++ b/libwasmvm/src/handle_vm_panic.rs
@@ -6,7 +6,7 @@ use std::any::Any;
 /// as those cases are not expected to happen during healthy operations.
 pub fn handle_vm_panic(what: &str, err: Box<dyn Any + Send + 'static>) {
     let err: &str = match (err.downcast_ref::<&str>(), err.downcast_ref::<String>()) {
-        (Some(str), ..) => *str,
+        (Some(str), ..) => str,
         (.., Some(str)) => str,
         (None, None) => "[unusable panic payload]",
     };

--- a/libwasmvm/src/handle_vm_panic.rs
+++ b/libwasmvm/src/handle_vm_panic.rs
@@ -5,14 +5,14 @@ use std::any::Any;
 /// We want to provide as much debug information as possible
 /// as those cases are not expected to happen during healthy operations.
 pub fn handle_vm_panic(what: &str, err: Box<dyn Any + Send + 'static>) {
-    let err = match (err.downcast_ref::<&str>(), err.downcast_ref::<String>()) {
+    let err: &str = match (err.downcast_ref::<&str>(), err.downcast_ref::<String>()) {
         (Some(str), ..) => *str,
         (.., Some(str)) => str,
         (None, None) => "[unusable panic payload]",
     };
 
     eprintln!("Panic in {what}:");
-    eprintln!("{err:?}");
+    eprintln!("{err}");
     eprintln!(
         "This indicates a panic in during the operations of libwasmvm/cosmwasm-vm.
 Such panics must not happen and are considered bugs. If you see this in any real-world or


### PR DESCRIPTION
Follow-up to #640

The Debug representation of `err` was a (failed) attempt to get as much information from the panic as possible. Now we di the string conversion directly such that `:?` is not needed anymore.