### PR TITLE
Switch to v3 module

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"os"
 
-	wasmvm "github.com/CosmWasm/wasmvm/v2"
+	wasmvm "github.com/CosmWasm/wasmvm/v3"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CosmWasm/wasmvm/v2
+module github.com/CosmWasm/wasmvm/v3
 
 go 1.22
 

--- a/ibc_test.go
+++ b/ibc_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/internal/api"
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/internal/api"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 const IBC_TEST_CONTRACT = "./testdata/ibc_reflect.wasm"

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 func TestValidateAddressFailure(t *testing.T) {

--- a/internal/api/callbacks.go
+++ b/internal/api/callbacks.go
@@ -41,7 +41,7 @@ import (
 	"runtime/debug"
 	"unsafe"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 // Note: we have to include all exports in the same file (at least since they both import bindings.h),

--- a/internal/api/iterator.go
+++ b/internal/api/iterator.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"sync"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 // frame stores all Iterators for one contract call

--- a/internal/api/iterator_test.go
+++ b/internal/api/iterator_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/internal/api/testdb"
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/internal/api/testdb"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 type queueData struct {

--- a/internal/api/lib.go
+++ b/internal/api/lib.go
@@ -15,7 +15,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 // Value types

--- a/internal/api/lib_test.go
+++ b/internal/api/lib_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 const (

--- a/internal/api/mock_failure.go
+++ b/internal/api/mock_failure.go
@@ -3,7 +3,7 @@ package api
 import (
 	"fmt"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 /***** Mock types.GoAPI ****/

--- a/internal/api/mocks.go
+++ b/internal/api/mocks.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/internal/api/testdb"
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/internal/api/testdb"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 /** helper constructors **/

--- a/internal/api/testdb/types.go
+++ b/internal/api/testdb/types.go
@@ -3,7 +3,7 @@ package testdb
 import (
 	"errors"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 var (

--- a/lib.go
+++ b/lib.go
@@ -8,7 +8,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 // Checksum represents a hash of the Wasm bytecode that serves as an ID. Must be generated from this library.

--- a/lib_libwasmvm.go
+++ b/lib_libwasmvm.go
@@ -9,8 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/CosmWasm/wasmvm/v2/internal/api"
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/internal/api"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 // VM is the main entry point to this library.

--- a/lib_libwasmvm_test.go
+++ b/lib_libwasmvm_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/internal/api"
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/internal/api"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 const (

--- a/lib_test.go
+++ b/lib_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/CosmWasm/wasmvm/v3/types"
 )
 
 func TestCreateChecksum(t *testing.T) {

--- a/version_cgo.go
+++ b/version_cgo.go
@@ -3,7 +3,7 @@
 package cosmwasm
 
 import (
-	"github.com/CosmWasm/wasmvm/v2/internal/api"
+	"github.com/CosmWasm/wasmvm/v3/internal/api"
 )
 
 func libwasmvmVersionImpl() (string, error) {


### PR DESCRIPTION
Needed for releasing a 3.0 version because of [insane Go rules](https://go.dev/blog/v2-go-modules).