### PR TITLE
Fix dead links in documentation

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -71,4 +71,4 @@ where the old name was deprecated.
 | `QueryResponse`                   | `QueryResult`                         | Brings consistency with the naming of the other results      |
 | `VoteMsg.Vote`                    | `VoteMsg.Option`                      | Brings consistency with Cosmos SDK naming                    |
 
-[ft]: https://stackoverflow.com/a/60073310
+[ft]: https://go.dev/doc/effective_go#mixed-caps

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -9,4 +9,4 @@ This will download the deployed builds [from GitHub releases](https://github.com
 
 If contracts are not available for some reason or you need to compile for
 an unreleased commit, you can build them manually using
-[these instructions](https://github.com/CosmWasm/cosmwasm/blob/v0.14.0-beta2/contracts/README.md#optimized-builds).
+[these instructions](https://github.com/CosmWasm/cosmwasm/blob/v1.5.11/contracts/README.md#optimized-builds).


### PR DESCRIPTION
##  Fix Dead Links

This PR resolves several broken links found in the documentation:

### Changes Made:
- **docs/MIGRATING.md**: Replace broken StackOverflow link with official Go documentation
- **testdata/README.md**: Update CosmWasm version from `v0.14.0-beta2` to `v1.5.11`

### Why These Changes:
-  Improves documentation reliability
-  Ensures all links are accessible to users
-  Updates references to current stable versions

