### PR TITLE
fix: correct bytes.Compare comparison logic

### DIFF
--- a/internal/api/testdb/memdb.go
+++ b/internal/api/testdb/memdb.go
@@ -23,7 +23,7 @@ type item struct {
 func (i *item) Less(other btree.Item) bool {
 	// this considers nil == []byte{}, but that's ok since we handle nil endpoints
 	// in iterators specially anyway
-	return bytes.Compare(i.key, other.(*item).key) == -1
+	return bytes.Compare(i.key, other.(*item).key) < 0
 }
 
 // newKey creates a new key item.

--- a/internal/api/testdb/memdb_iterator.go
+++ b/internal/api/testdb/memdb_iterator.go
@@ -61,7 +61,7 @@ func newMemDBIteratorMtxChoice(db *MemDB, start []byte, end []byte, reverse bool
 				skipEqual = nil
 				return true
 			}
-			if abortLessThan != nil && bytes.Compare(item.key, abortLessThan) == -1 {
+			if abortLessThan != nil && bytes.Compare(item.key, abortLessThan) < 0 {
 				return false
 			}
 			select {


### PR DESCRIPTION
Fix incorrect bytes.Compare usage (== -1 → < 0) to properly follow Go comparison contract.