### PR TITLE
Add checksum JSON validation tests

### DIFF
--- a/types/types_test.go
+++ b/types/types_test.go
@@ -19,6 +19,46 @@ func TestChecksumString(t *testing.T) {
 	assert.Equal(t, hexRepr, checksumRepr)
 }
 
+func TestChecksumJSON(t *testing.T) {
+	hexRepr := "cd6ff9ff3faea9b3d0224a7e0d1133e6eae1b7800e8392441200056986c358a9"
+	checksum := ForceNewChecksum(hexRepr)
+
+	bz, err := json.Marshal(checksum)
+	require.NoError(t, err)
+	require.Equal(t, `"`+hexRepr+`"`, string(bz))
+
+	var parsed Checksum
+	err = json.Unmarshal(bz, &parsed)
+	require.NoError(t, err)
+	require.Equal(t, checksum, parsed)
+}
+
+func TestChecksumJSONRejectsInvalidInput(t *testing.T) {
+	cases := map[string]string{
+		"invalid hex":  `"not hex"`,
+		"too short":    `"cd6ff9ff3faea9b3d0224a7e0d1133e6eae1b7800e8392441200056986c358"`,
+		"too long":     `"cd6ff9ff3faea9b3d0224a7e0d1133e6eae1b7800e8392441200056986c358a900"`,
+		"not a string": `123`,
+	}
+
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			var checksum Checksum
+			err := json.Unmarshal([]byte(input), &checksum)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestForceNewChecksumPanicsForInvalidInput(t *testing.T) {
+	require.Panics(t, func() {
+		ForceNewChecksum("not hex")
+	})
+	require.Panics(t, func() {
+		ForceNewChecksum("cd6ff9ff3faea9b3d0224a7e0d1133e6eae1b7800e8392441200056986c358")
+	})
+}
+
 func TestUint64JSON(t *testing.T) {
 	var u Uint64
 


### PR DESCRIPTION
## Summary

This PR adds focused tests for the `types.Checksum` JSON behavior and constructor validation.

The new coverage verifies that:

- valid checksums round-trip through JSON as hex strings
- invalid checksum JSON is rejected for malformed hex, wrong length, and non-string input
- `ForceNewChecksum` panics for invalid input as documented

## Motivation

`Checksum` is used as the Go representation of Wasm code hashes and has custom JSON marshal/unmarshal logic with a strict 32-byte length requirement. These tests make that public behavior explicit and help prevent regressions around checksum serialization at the Go/Rust boundary.

## Testing

```sh
go test ./types -count=1
CGO_ENABLED=0 go test ./types -count=1
go test ./... -count=1
git diff --check